### PR TITLE
DD-1178 dd-sword2 returns state INVALID for deposit if deposit could not be read

### DIFF
--- a/src/main/java/nl/knaw/dans/sword2/DdSword2Application.java
+++ b/src/main/java/nl/knaw/dans/sword2/DdSword2Application.java
@@ -21,6 +21,8 @@ import io.dropwizard.auth.AuthDynamicFeature;
 import io.dropwizard.auth.AuthValueFactoryProvider;
 import io.dropwizard.auth.basic.BasicCredentialAuthFilter;
 import io.dropwizard.client.HttpClientBuilder;
+import io.dropwizard.configuration.EnvironmentVariableSubstitutor;
+import io.dropwizard.configuration.SubstitutingSourceProvider;
 import io.dropwizard.forms.MultiPartBundle;
 import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
@@ -68,6 +70,8 @@ public class DdSword2Application extends Application<DdSword2Configuration> {
     @Override
     public void initialize(final Bootstrap<DdSword2Configuration> bootstrap) {
         bootstrap.addBundle(new MultiPartBundle());
+        bootstrap.setConfigurationSourceProvider(new SubstitutingSourceProvider(bootstrap.getConfigurationSourceProvider(),
+                new EnvironmentVariableSubstitutor(false)));
     }
 
     @Override

--- a/src/main/java/nl/knaw/dans/sword2/core/service/DepositPropertiesManagerImpl.java
+++ b/src/main/java/nl/knaw/dans/sword2/core/service/DepositPropertiesManagerImpl.java
@@ -74,9 +74,8 @@ public class DepositPropertiesManagerImpl implements DepositPropertiesManager {
         try {
             var config = builder.getConfiguration();
             return mapToDeposit(config);
-        }
-        catch (Throwable cex) {
-            throw new InvalidDepositException("Unable to load deposit properties", cex);
+        } catch (ConfigurationException e) {
+            throw new IllegalStateException("Could not load properties file", e);
         }
     }
 

--- a/src/test/java/nl/knaw/dans/sword2/TestFixture.java
+++ b/src/test/java/nl/knaw/dans/sword2/TestFixture.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2022 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.sword2;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+public abstract class TestFixture {
+
+    protected Path testDir = Paths.get("target/test", getClass().getSimpleName());
+
+}

--- a/src/test/java/nl/knaw/dans/sword2/TestFixture.java
+++ b/src/test/java/nl/knaw/dans/sword2/TestFixture.java
@@ -18,8 +18,15 @@ package nl.knaw.dans.sword2;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
+/**
+ * Each test class has a workspace under
+ * <pre>
+ *     target/test/<test-class-name>/
+ * </pre>
+ *
+ * This fixture makes sure that the field <code>testDir</code> is initialized to point to that directory. Subclasses are responsible for initializing the actual directory.
+ */
 public abstract class TestFixture {
 
     protected Path testDir = Paths.get("target/test", getClass().getSimpleName());
-
 }

--- a/src/test/java/nl/knaw/dans/sword2/TestFixtureExt.java
+++ b/src/test/java/nl/knaw/dans/sword2/TestFixtureExt.java
@@ -23,14 +23,22 @@ import org.apache.commons.text.StringSubstitutor;
 
 import java.util.Collections;
 
+/**
+ * Fixture for integration tests that run the whole dropwizard app using the DropwizardAppExtension.
+ */
 public abstract class TestFixtureExt extends TestFixture {
 
     protected final DropwizardAppExtension<DdSword2Configuration> EXT;
 
+    /**
+     * Initializes the app with the giving config.yml. The variable <code>${TEST_DIR}</code> can be used in config.yml to resolve to <code>testDir</code>.
+     *
+     * @param configYml the config.yml to use
+     */
     protected TestFixtureExt(String configYml) {
         EXT = new DropwizardAppExtension<>(
             DdSword2Application.class,
             ResourceHelpers.resourceFilePath(configYml),
             new SubstitutingSourceProvider(new FileConfigurationSourceProvider(), new StringSubstitutor(Collections.singletonMap("TEST_DIR", testDir.toString()))));
-           }
+    }
 }

--- a/src/test/java/nl/knaw/dans/sword2/TestFixtureExt.java
+++ b/src/test/java/nl/knaw/dans/sword2/TestFixtureExt.java
@@ -1,0 +1,21 @@
+package nl.knaw.dans.sword2;
+
+import io.dropwizard.configuration.FileConfigurationSourceProvider;
+import io.dropwizard.configuration.SubstitutingSourceProvider;
+import io.dropwizard.testing.ResourceHelpers;
+import io.dropwizard.testing.junit5.DropwizardAppExtension;
+import org.apache.commons.text.StringSubstitutor;
+
+import java.util.Collections;
+
+public abstract class TestFixtureExt extends TestFixture {
+
+    protected final DropwizardAppExtension<DdSword2Configuration> EXT;
+
+    protected TestFixtureExt(String configYml) {
+        EXT = new DropwizardAppExtension<>(
+            DdSword2Application.class,
+            ResourceHelpers.resourceFilePath(configYml),
+            new SubstitutingSourceProvider(new FileConfigurationSourceProvider(), new StringSubstitutor(Collections.singletonMap("TEST_DIR", testDir.toString()))));
+           }
+}

--- a/src/test/java/nl/knaw/dans/sword2/TestFixtureExt.java
+++ b/src/test/java/nl/knaw/dans/sword2/TestFixtureExt.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2022 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package nl.knaw.dans.sword2;
 
 import io.dropwizard.configuration.FileConfigurationSourceProvider;

--- a/src/test/java/nl/knaw/dans/sword2/core/service/BagExtractorImplTest.java
+++ b/src/test/java/nl/knaw/dans/sword2/core/service/BagExtractorImplTest.java
@@ -44,7 +44,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class BagExtractorImplTest extends TestFixture {
 
-
     private final FileService fileService = new FileServiceImpl();
     private final ZipService zipService = new ZipServiceImpl(fileService);
     private final Path testPath = testDir.resolve("bagextractor/");

--- a/src/test/java/nl/knaw/dans/sword2/core/service/BagExtractorImplTest.java
+++ b/src/test/java/nl/knaw/dans/sword2/core/service/BagExtractorImplTest.java
@@ -15,6 +15,7 @@
  */
 package nl.knaw.dans.sword2.core.service;
 
+import nl.knaw.dans.sword2.TestFixture;
 import nl.knaw.dans.sword2.core.exceptions.InvalidDepositException;
 import nl.knaw.dans.sword2.core.exceptions.InvalidPartialFileException;
 import nl.knaw.dans.sword2.core.exceptions.NotEnoughDiskSpaceException;
@@ -41,11 +42,12 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-class BagExtractorImplTest {
+class BagExtractorImplTest extends TestFixture {
+
 
     private final FileService fileService = new FileServiceImpl();
     private final ZipService zipService = new ZipServiceImpl(fileService);
-    private final Path testPath = Path.of("data/tmp/bagextractor/");
+    private final Path testPath = testDir.resolve("bagextractor/");
     private final BagItManager bagItManager = Mockito.mock(BagItManager.class);
     private final ChecksumCalculator checksumCalculator = new ChecksumCalculatorImpl();
     private final FilesystemSpaceVerifier filesystemSpaceVerifier = Mockito.mock(FilesystemSpaceVerifier.class);

--- a/src/test/java/nl/knaw/dans/sword2/resources/CollectionResourceBagSenderIntegrationTest.java
+++ b/src/test/java/nl/knaw/dans/sword2/resources/CollectionResourceBagSenderIntegrationTest.java
@@ -24,6 +24,7 @@ import net.lingala.zip4j.model.ZipParameters;
 import nl.knaw.dans.sword2.DdSword2Application;
 import nl.knaw.dans.sword2.DdSword2Configuration;
 import nl.knaw.dans.sword2.TestFixture;
+import nl.knaw.dans.sword2.TestFixtureExt;
 import nl.knaw.dans.sword2.api.entry.Entry;
 import nl.knaw.dans.sword2.core.Deposit;
 import nl.knaw.dans.sword2.core.DepositState;
@@ -55,7 +56,7 @@ import java.nio.file.Paths;
 import java.security.NoSuchAlgorithmException;
 
 @ExtendWith(DropwizardExtensionsSupport.class)
-class CollectionResourceBagSenderIntegrationTest extends TestFixture {
+class CollectionResourceBagSenderIntegrationTest extends TestFixtureExt {
     private static final Logger log = LoggerFactory.getLogger(CollectionResourceBagSenderIntegrationTest.class);
 
     private static final FileService fileService = new FileServiceImpl();
@@ -64,10 +65,9 @@ class CollectionResourceBagSenderIntegrationTest extends TestFixture {
 
     private final Path BASE_PATH = testDir.resolve("bagsender");
 
-    private final DropwizardAppExtension<DdSword2Configuration> EXT = new DropwizardAppExtension<>(
-        DdSword2Application.class,
-        ResourceHelpers.resourceFilePath("test-etc/config-bagsender.yml")
-    );
+    public CollectionResourceBagSenderIntegrationTest() {
+        super("test-etc/config-bagsender.yml");
+    }
 
     @BeforeEach
     void startUp() throws IOException {
@@ -76,7 +76,7 @@ class CollectionResourceBagSenderIntegrationTest extends TestFixture {
     }
 
     @AfterEach
-    void tearDown() throws IOException {
+    void tearDown() {
         ((LoggerContext) org.slf4j.LoggerFactory.getILoggerFactory()).stop();
     }
 

--- a/src/test/java/nl/knaw/dans/sword2/resources/CollectionResourceBagSenderIntegrationTest.java
+++ b/src/test/java/nl/knaw/dans/sword2/resources/CollectionResourceBagSenderIntegrationTest.java
@@ -23,6 +23,7 @@ import net.lingala.zip4j.ZipFile;
 import net.lingala.zip4j.model.ZipParameters;
 import nl.knaw.dans.sword2.DdSword2Application;
 import nl.knaw.dans.sword2.DdSword2Configuration;
+import nl.knaw.dans.sword2.TestFixture;
 import nl.knaw.dans.sword2.api.entry.Entry;
 import nl.knaw.dans.sword2.core.Deposit;
 import nl.knaw.dans.sword2.core.DepositState;
@@ -50,17 +51,18 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.security.NoSuchAlgorithmException;
 
 @ExtendWith(DropwizardExtensionsSupport.class)
-class CollectionResourceBagSenderIntegrationTest {
+class CollectionResourceBagSenderIntegrationTest extends TestFixture {
     private static final Logger log = LoggerFactory.getLogger(CollectionResourceBagSenderIntegrationTest.class);
 
     private static final FileService fileService = new FileServiceImpl();
     private static final ChecksumCalculator checksumCalculator = new ChecksumCalculatorImpl();
     private static final DepositPropertiesManager depositPropertiesManager = new DepositPropertiesManagerImpl();
 
-    private static final Path BASE_PATH = Path.of("data/tmp/bagsender");
+    private final Path BASE_PATH = testDir.resolve("bagsender");
 
     private final DropwizardAppExtension<DdSword2Configuration> EXT = new DropwizardAppExtension<>(
         DdSword2Application.class,
@@ -69,18 +71,12 @@ class CollectionResourceBagSenderIntegrationTest {
 
     @BeforeEach
     void startUp() throws IOException {
-        try {
-            FileUtils.deleteDirectory(BASE_PATH.toFile());
-        }
-        catch (Exception e) {
-            log.warn("Unable to delete directory");
-        }
+        FileUtils.deleteDirectory(BASE_PATH.toFile());
         fileService.ensureDirectoriesExist(BASE_PATH);
     }
 
     @AfterEach
     void tearDown() throws IOException {
-        FileUtils.deleteDirectory(BASE_PATH.toFile());
         ((LoggerContext) org.slf4j.LoggerFactory.getILoggerFactory()).stop();
     }
 

--- a/src/test/java/nl/knaw/dans/sword2/resources/CollectionResourceImplIntegrationTest.java
+++ b/src/test/java/nl/knaw/dans/sword2/resources/CollectionResourceImplIntegrationTest.java
@@ -27,6 +27,7 @@ import io.dropwizard.testing.junit5.DropwizardExtensionsSupport;
 import nl.knaw.dans.sword2.DdSword2Application;
 import nl.knaw.dans.sword2.DdSword2Configuration;
 import nl.knaw.dans.sword2.TestFixture;
+import nl.knaw.dans.sword2.TestFixtureExt;
 import nl.knaw.dans.sword2.api.entry.Entry;
 import nl.knaw.dans.sword2.api.error.Error;
 import nl.knaw.dans.sword2.api.statement.Feed;
@@ -68,12 +69,12 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ExtendWith(DropwizardExtensionsSupport.class)
-class CollectionResourceImplIntegrationTest extends TestFixture {
+class CollectionResourceImplIntegrationTest extends TestFixtureExt {
 
-    private final DropwizardAppExtension<DdSword2Configuration> EXT = new DropwizardAppExtension<>(
-            DdSword2Application.class,
-            ResourceHelpers.resourceFilePath("test-etc/config-regular.yml"),
-            new SubstitutingSourceProvider(new FileConfigurationSourceProvider(), new StringSubstitutor(Collections.singletonMap("TEST_DIR", testDir.toString()))));
+    public CollectionResourceImplIntegrationTest() {
+        super("test-etc/config-regular.yml");
+    }
+
 
     @BeforeEach
     void startUp() throws IOException {
@@ -82,7 +83,7 @@ class CollectionResourceImplIntegrationTest extends TestFixture {
     }
 
     @AfterEach
-    void tearDown() throws IOException {
+    void tearDown() {
         ((LoggerContext) org.slf4j.LoggerFactory.getILoggerFactory()).stop();
     }
 

--- a/src/test/java/nl/knaw/dans/sword2/resources/CollectionResourceImplIntegrationTest.java
+++ b/src/test/java/nl/knaw/dans/sword2/resources/CollectionResourceImplIntegrationTest.java
@@ -16,11 +16,17 @@
 package nl.knaw.dans.sword2.resources;
 
 import ch.qos.logback.classic.LoggerContext;
+import io.dropwizard.configuration.ConfigurationSourceProvider;
+import io.dropwizard.configuration.FileConfigurationSourceProvider;
+import io.dropwizard.configuration.ResourceConfigurationSourceProvider;
+import io.dropwizard.configuration.SubstitutingSourceProvider;
+import io.dropwizard.testing.ConfigOverride;
 import io.dropwizard.testing.ResourceHelpers;
 import io.dropwizard.testing.junit5.DropwizardAppExtension;
 import io.dropwizard.testing.junit5.DropwizardExtensionsSupport;
 import nl.knaw.dans.sword2.DdSword2Application;
 import nl.knaw.dans.sword2.DdSword2Configuration;
+import nl.knaw.dans.sword2.TestFixture;
 import nl.knaw.dans.sword2.api.entry.Entry;
 import nl.knaw.dans.sword2.api.error.Error;
 import nl.knaw.dans.sword2.api.statement.Feed;
@@ -31,6 +37,7 @@ import org.apache.commons.configuration2.builder.FileBasedConfigurationBuilder;
 import org.apache.commons.configuration2.builder.fluent.Parameters;
 import org.apache.commons.configuration2.ex.ConfigurationException;
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.text.StringSubstitutor;
 import org.glassfish.jersey.media.multipart.BodyPart;
 import org.glassfish.jersey.media.multipart.MultiPart;
 import org.glassfish.jersey.media.multipart.MultiPartFeature;
@@ -47,9 +54,11 @@ import javax.xml.bind.JAXBException;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Locale;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -59,33 +68,32 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ExtendWith(DropwizardExtensionsSupport.class)
-class CollectionResourceImplIntegrationTest {
+class CollectionResourceImplIntegrationTest extends TestFixture {
 
     private final DropwizardAppExtension<DdSword2Configuration> EXT = new DropwizardAppExtension<>(
-        DdSword2Application.class,
-        ResourceHelpers.resourceFilePath("test-etc/config-regular.yml")
-    );
+            DdSword2Application.class,
+            ResourceHelpers.resourceFilePath("test-etc/config-regular.yml"),
+            new SubstitutingSourceProvider(new FileConfigurationSourceProvider(), new StringSubstitutor(Collections.singletonMap("TEST_DIR", testDir.toString()))));
 
     @BeforeEach
     void startUp() throws IOException {
-        FileUtils.deleteDirectory(Path.of("data/tmp").toFile());
-        new FileServiceImpl().ensureDirectoriesExist(Path.of("data/tmp/1"));
+        FileUtils.deleteDirectory(testDir.toFile());
+        new FileServiceImpl().ensureDirectoriesExist(testDir.resolve("1"));
     }
 
     @AfterEach
     void tearDown() throws IOException {
-        FileUtils.deleteDirectory(Path.of("data/tmp").toFile());
-        ((LoggerContext)org.slf4j.LoggerFactory.getILoggerFactory()).stop();
+        ((LoggerContext) org.slf4j.LoggerFactory.getILoggerFactory()).stop();
     }
 
     Builder buildRequest(String path) {
         var url = String.format("http://localhost:%s%s", EXT.getLocalPort(), path);
 
         return RequestClientBuilder.buildClient()
-            .target(url)
-            .register(MultiPartFeature.class)
-            .request()
-            .header("authorization", "Basic dXNlcjAwMTp1c2VyMDAx");
+                .target(url)
+                .register(MultiPartFeature.class)
+                .request()
+                .header("authorization", "Basic dXNlcjAwMTp1c2VyMDAx");
     }
 
     @Test
@@ -95,20 +103,20 @@ class CollectionResourceImplIntegrationTest {
         assert path != null;
 
         var result = buildRequest("/collection/1")
-            .header("content-type", "application/zip")
-            .header("content-md5", "bc27e20467a773501a4ae37fb85a9c3f")
-            .header("content-disposition", "attachment; filename=bag.zip")
-            .header("in-progress", "true")
-            .post(Entity.entity(path.openStream(), MediaType.valueOf("application/zip")));
+                .header("content-type", "application/zip")
+                .header("content-md5", "bc27e20467a773501a4ae37fb85a9c3f")
+                .header("content-disposition", "attachment; filename=bag.zip")
+                .header("in-progress", "true")
+                .post(Entity.entity(path.openStream(), MediaType.valueOf("application/zip")));
 
         assertEquals(201, result.getStatus());
 
         var receipt = result.readEntity(Entry.class);
         var parts = receipt.getId()
-            .split("/");
+                .split("/");
         var id = parts[parts.length - 1];
 
-        var firstPath = Path.of("data/tmp/1/uploads/", id);
+        var firstPath = testDir.resolve("1/uploads/").resolve(id);
 
         assertTrue(Files.exists(firstPath.resolve("deposit.properties")));
         assertTrue(Files.exists(firstPath.resolve("bag.zip")));
@@ -124,7 +132,7 @@ class CollectionResourceImplIntegrationTest {
         assertEquals("Deposit is open for additional data", config.getString("state.description"));
 
         var statusResult = buildRequest("/statement/" + id)
-            .get();
+                .get();
 
         var feed = statusResult.readEntity(Feed.class);
         assertEquals("http://localhost:20320/statement/" + id, feed.getId());
@@ -137,21 +145,21 @@ class CollectionResourceImplIntegrationTest {
         assert path != null;
 
         var result = buildRequest("/collection/1")
-            .header("content-type", "application/zip")
-            .header("content-md5", "bc27e20467a773501a4ae37fb85a9c3f")
-            .header("content-disposition", "attachment; filename=bag.zip")
-            .header("in-progress", "true")
-            .post(Entity.entity(path.openStream(), MediaType.valueOf("application/zip")));
+                .header("content-type", "application/zip")
+                .header("content-md5", "bc27e20467a773501a4ae37fb85a9c3f")
+                .header("content-disposition", "attachment; filename=bag.zip")
+                .header("in-progress", "true")
+                .post(Entity.entity(path.openStream(), MediaType.valueOf("application/zip")));
 
         assertEquals(201, result.getStatus());
 
         var receipt = result.readEntity(Entry.class);
         var parts = receipt.getId()
-            .split("/");
+                .split("/");
         var id = parts[parts.length - 1];
 
         var statusResult = buildRequest("/container/" + id)
-            .get();
+                .get();
 
         var feed = statusResult.readEntity(Entry.class);
         assertEquals("http://localhost:20320/container/" + id, feed.getId());
@@ -164,21 +172,21 @@ class CollectionResourceImplIntegrationTest {
         assert path != null;
 
         var result = buildRequest("/collection/1")
-            .header("content-type", "application/zip")
-            .header("content-md5", "bc27e20467a773501a4ae37fb85a9c3f")
-            .header("content-disposition", "attachment; filename=bag.zip")
-            .header("in-progress", "true")
-            .post(Entity.entity(path.openStream(), MediaType.valueOf("application/zip")));
+                .header("content-type", "application/zip")
+                .header("content-md5", "bc27e20467a773501a4ae37fb85a9c3f")
+                .header("content-disposition", "attachment; filename=bag.zip")
+                .header("in-progress", "true")
+                .post(Entity.entity(path.openStream(), MediaType.valueOf("application/zip")));
 
         assertEquals(201, result.getStatus());
 
         var receipt = result.readEntity(Entry.class);
         var parts = receipt.getId()
-            .split("/");
+                .split("/");
         var id = parts[parts.length - 1];
 
         var statusResult = buildRequest("/container/" + id)
-            .head();
+                .head();
 
         assertEquals(200, statusResult.getStatus());
         assertEquals("http://localhost:20320/container/" + id, statusResult.getHeaderString("location"));
@@ -187,13 +195,14 @@ class CollectionResourceImplIntegrationTest {
     @Test
     void testDepositReceiptFromContainerEndpointNotFound() {
         var statusResult = buildRequest("/container/" + "random_id")
-            .get();
+                .get();
 
         assertEquals(404, statusResult.getStatus());
     }
 
     @Test
-    void testZipInParts() throws IOException, ConfigurationException, NoSuchAlgorithmException, InterruptedException {
+    void testZipInParts() throws
+            IOException, ConfigurationException, NoSuchAlgorithmException, InterruptedException {
         var path = getClass().getResource("/zips/audiences.zip");
         assert path != null;
 
@@ -203,11 +212,11 @@ class CollectionResourceImplIntegrationTest {
 
         var checksum = md5Checksum(firstPart);
         var result = buildRequest("/collection/1")
-            .header("content-type", "application/octet-stream")
-            .header("content-md5", checksum)
-            .header("content-disposition", "attachment; filename=bag.zip.1")
-            .header("in-progress", "true")
-            .post(Entity.entity(firstPart, MediaType.valueOf("application/octet-stream")));
+                .header("content-type", "application/octet-stream")
+                .header("content-md5", checksum)
+                .header("content-disposition", "attachment; filename=bag.zip.1")
+                .header("in-progress", "true")
+                .post(Entity.entity(firstPart, MediaType.valueOf("application/octet-stream")));
 
         assertEquals(201, result.getStatus());
 
@@ -218,22 +227,22 @@ class CollectionResourceImplIntegrationTest {
         var secondPart = Arrays.copyOfRange(bytes, bagSize, bagSize * 2);
         var checksum2 = md5Checksum(secondPart);
         var result2 = buildRequest("/container/" + id)
-            .header("content-type", "application/octet-stream")
-            .header("content-md5", checksum2)
-            .header("content-disposition", "attachment; filename=bag.zip.2")
-            .header("in-progress", "true")
-            .post(Entity.entity(secondPart, MediaType.valueOf("application/octet-stream")));
+                .header("content-type", "application/octet-stream")
+                .header("content-md5", checksum2)
+                .header("content-disposition", "attachment; filename=bag.zip.2")
+                .header("in-progress", "true")
+                .post(Entity.entity(secondPart, MediaType.valueOf("application/octet-stream")));
         assertEquals(200, result2.getStatus());
 
         var thirdPart = Arrays.copyOfRange(bytes, bagSize * 2, bytes.length);
         var checksum3 = md5Checksum(thirdPart);
 
         var result3 = buildRequest("/container/" + id)
-            .header("content-type", "application/octet-stream")
-            .header("content-md5", checksum3)
-            .header("content-disposition", "attachment; filename=bag.zip.3")
-            .header("in-progress", "false")
-            .post(Entity.entity(thirdPart, MediaType.valueOf("application/zip")));
+                .header("content-type", "application/octet-stream")
+                .header("content-md5", checksum3)
+                .header("content-disposition", "attachment; filename=bag.zip.3")
+                .header("in-progress", "false")
+                .post(Entity.entity(thirdPart, MediaType.valueOf("application/zip")));
         assertEquals(200, result3.getStatus());
 
         var count = 0;
@@ -253,7 +262,7 @@ class CollectionResourceImplIntegrationTest {
 
         assertEquals("SUBMITTED", state);
 
-        var firstPath = Path.of("data/tmp/1/deposits/", id);
+        var firstPath = testDir.resolve("1/deposits/").resolve(id);
         assertTrue(Files.exists(firstPath.resolve("deposit.properties")));
         assertTrue(Files.exists(firstPath.resolve("audiences/bagit.txt")));
         assertFalse(Files.exists(firstPath.resolve("bag.zip.1")));
@@ -262,7 +271,8 @@ class CollectionResourceImplIntegrationTest {
     }
 
     @Test
-    void testZipInPartsWithInvalidHash() throws IOException, ConfigurationException, NoSuchAlgorithmException, InterruptedException {
+    void testZipInPartsWithInvalidHash() throws
+            IOException, ConfigurationException, NoSuchAlgorithmException, InterruptedException {
         var path = getClass().getResource("/zips/audiences.zip");
         assert path != null;
 
@@ -272,11 +282,11 @@ class CollectionResourceImplIntegrationTest {
 
         var checksum = md5Checksum(firstPart);
         var result = buildRequest("/collection/1")
-            .header("content-type", "application/octet-stream")
-            .header("content-md5", checksum)
-            .header("content-disposition", "attachment; filename=bag.zip.1")
-            .header("in-progress", "true")
-            .post(Entity.entity(firstPart, MediaType.valueOf("application/octet-stream")));
+                .header("content-type", "application/octet-stream")
+                .header("content-md5", checksum)
+                .header("content-disposition", "attachment; filename=bag.zip.1")
+                .header("in-progress", "true")
+                .post(Entity.entity(firstPart, MediaType.valueOf("application/octet-stream")));
 
         assertEquals(201, result.getStatus());
 
@@ -287,25 +297,25 @@ class CollectionResourceImplIntegrationTest {
         var secondPart = Arrays.copyOfRange(bytes, bagSize, bagSize * 2);
         var checksum2 = md5Checksum(secondPart);
         var result2 = buildRequest("/container/" + id)
-            .header("content-type", "application/octet-stream")
-            .header("content-md5", checksum2)
-            .header("content-disposition", "attachment; filename=bag.zip.2")
-            .header("in-progress", "true")
-            .post(Entity.entity(secondPart, MediaType.valueOf("application/octet-stream")));
+                .header("content-type", "application/octet-stream")
+                .header("content-md5", checksum2)
+                .header("content-disposition", "attachment; filename=bag.zip.2")
+                .header("in-progress", "true")
+                .post(Entity.entity(secondPart, MediaType.valueOf("application/octet-stream")));
         assertEquals(200, result2.getStatus());
 
         var thirdPart = Arrays.copyOfRange(bytes, bagSize * 2, bytes.length);
         var checksum3 = md5Checksum(thirdPart);
 
         var result3 = buildRequest("/container/" + id)
-            .header("content-type", "application/octet-stream")
-            .header("content-md5", "invalid_checksum")
-            .header("content-disposition", "attachment; filename=bag.zip.3")
-            .header("in-progress", "false")
-            .post(Entity.entity(thirdPart, MediaType.valueOf("application/zip")));
+                .header("content-type", "application/octet-stream")
+                .header("content-md5", "invalid_checksum")
+                .header("content-disposition", "attachment; filename=bag.zip.3")
+                .header("in-progress", "false")
+                .post(Entity.entity(thirdPart, MediaType.valueOf("application/zip")));
         assertEquals(412, result3.getStatus());
 
-        var firstPath = Path.of("data/tmp/1/uploads/", id);
+        var firstPath = testDir.resolve("1/uploads/").resolve(id);
         assertTrue(Files.exists(firstPath.resolve("bag.zip.1")));
         assertTrue(Files.exists(firstPath.resolve("bag.zip.2")));
         assertTrue(Files.exists(firstPath.resolve("bag.zip.3")));
@@ -318,11 +328,11 @@ class CollectionResourceImplIntegrationTest {
         assert path != null;
 
         var result = buildRequest("/collection/1")
-            .header("content-type", "application/zip")
-            .header("content-md5", "bc27e20467a773501a4ae37fb85a9c3f")
-            .header("in-progress", "false")
-            .header("content-disposition", "attachment; filename=bag.zip")
-            .post(Entity.entity(path.openStream(), MediaType.valueOf("application/zip")));
+                .header("content-type", "application/zip")
+                .header("content-md5", "bc27e20467a773501a4ae37fb85a9c3f")
+                .header("in-progress", "false")
+                .header("content-disposition", "attachment; filename=bag.zip")
+                .post(Entity.entity(path.openStream(), MediaType.valueOf("application/zip")));
 
         assertEquals(201, result.getStatus());
 
@@ -336,10 +346,10 @@ class CollectionResourceImplIntegrationTest {
         // waiting at most 5 seconds for the background thread to handle this
         while (count < 5) {
             var statement = buildRequest("/statement/" + id)
-                .get(Feed.class);
+                    .get(Feed.class);
 
             state = statement.getCategory()
-                .getTerm();
+                    .getTerm();
 
             if (state.equals("SUBMITTED")) {
                 break;
@@ -350,7 +360,7 @@ class CollectionResourceImplIntegrationTest {
 
         assertEquals("SUBMITTED", state);
 
-        var firstPath = Path.of("data/tmp/1/deposits/" + id);
+        var firstPath = testDir.resolve("1/deposits").resolve(id);
         var config = getProperties(firstPath);
 
         assertNotNull(config.getString("bag-store.bag-id"));
@@ -371,11 +381,11 @@ class CollectionResourceImplIntegrationTest {
         assert path != null;
 
         var result = buildRequest("/collection/1")
-            .header("content-type", "application/zip")
-            .header("content-md5", "db45b2cfeb223d35d25a6d5208b528db")
-            .header("in-progress", "false")
-            .header("content-disposition", "attachment; filename=bag.zip")
-            .post(Entity.entity(path.openStream(), MediaType.valueOf("application/zip")));
+                .header("content-type", "application/zip")
+                .header("content-md5", "db45b2cfeb223d35d25a6d5208b528db")
+                .header("in-progress", "false")
+                .header("content-disposition", "attachment; filename=bag.zip")
+                .post(Entity.entity(path.openStream(), MediaType.valueOf("application/zip")));
 
         assertEquals(201, result.getStatus());
 
@@ -389,10 +399,10 @@ class CollectionResourceImplIntegrationTest {
         // waiting at most 5 seconds for the background thread to handle this
         while (count < 5) {
             var statement = buildRequest("/statement/" + id)
-                .get(Feed.class);
+                    .get(Feed.class);
 
             state = statement.getCategory()
-                .getTerm();
+                    .getTerm();
 
             if (state.equals("INVALID")) {
                 break;
@@ -403,7 +413,7 @@ class CollectionResourceImplIntegrationTest {
 
         assertEquals("INVALID", state);
 
-        var firstPath = Path.of("data/tmp/1/uploads/" + id);
+        var firstPath = testDir.resolve("1/uploads").resolve(id);
         var config = getProperties(firstPath);
 
         assertNotNull(config.getString("bag-store.bag-id"));
@@ -426,11 +436,11 @@ class CollectionResourceImplIntegrationTest {
         assert path != null;
 
         var result = buildRequest("/collection/1")
-            .header("content-type", "application/zip")
-            .header("content-md5", "invalid_hash")
-            .header("in-progress", "false")
-            .header("content-disposition", "attachment; filename=bag.zip")
-            .post(Entity.entity(path.openStream(), MediaType.valueOf("application/zip")));
+                .header("content-type", "application/zip")
+                .header("content-md5", "invalid_hash")
+                .header("in-progress", "false")
+                .header("content-disposition", "attachment; filename=bag.zip")
+                .post(Entity.entity(path.openStream(), MediaType.valueOf("application/zip")));
 
         assertEquals(412, result.getStatus());
 
@@ -456,9 +466,9 @@ class CollectionResourceImplIntegrationTest {
         multiPart.setMediaType(MediaType.valueOf("multipart/related"));
 
         var result = buildRequest("/collection/1")
-            .header("content-length", 1000)
-            .header("in-progress", "true")
-            .post(Entity.entity(multiPart, multiPart.getMediaType()));
+                .header("content-length", 1000)
+                .header("in-progress", "true")
+                .post(Entity.entity(multiPart, multiPart.getMediaType()));
 
         assertEquals(405, result.getStatus());
     }
@@ -470,11 +480,11 @@ class CollectionResourceImplIntegrationTest {
         assert path != null;
 
         var result = buildRequest("/collection/123")
-            .header("content-type", "application/zip")
-            .header("content-md5", "bc27e20467a773501a4ae37fb85a9c3f")
-            .header("content-disposition", "attachment; filename=bag.zip")
-            .header("in-progress", "true")
-            .post(Entity.entity(path.openStream(), MediaType.valueOf("application/zip")));
+                .header("content-type", "application/zip")
+                .header("content-md5", "bc27e20467a773501a4ae37fb85a9c3f")
+                .header("content-disposition", "attachment; filename=bag.zip")
+                .header("in-progress", "true")
+                .post(Entity.entity(path.openStream(), MediaType.valueOf("application/zip")));
 
         assertEquals(405, result.getStatus());
 
@@ -491,11 +501,11 @@ class CollectionResourceImplIntegrationTest {
         assert path != null;
 
         var result = buildRequest("/collection/123")
-            .header("content-type", "application/zip")
-            .header("content-md5", "bc27e20467a773501a4ae37fb85a9c3f")
-            .header("content-disposition", "attachment; filename=bag.zip")
-            .header("in-progress", "this is something else")
-            .post(Entity.entity(path.openStream(), MediaType.valueOf("application/zip")));
+                .header("content-type", "application/zip")
+                .header("content-md5", "bc27e20467a773501a4ae37fb85a9c3f")
+                .header("content-disposition", "attachment; filename=bag.zip")
+                .header("in-progress", "this is something else")
+                .post(Entity.entity(path.openStream(), MediaType.valueOf("application/zip")));
 
         assertEquals(400, result.getStatus());
 
@@ -511,10 +521,10 @@ class CollectionResourceImplIntegrationTest {
         assert path != null;
 
         var result = buildRequest("/collection/1")
-            .header("content-length", 1000)
-            .header("in-progress", "true")
-            .header("content-type", "application/atom+xml")
-            .post(Entity.entity(path.openStream(), MediaType.valueOf("application/atom+xml")));
+                .header("content-length", 1000)
+                .header("in-progress", "true")
+                .header("content-type", "application/atom+xml")
+                .post(Entity.entity(path.openStream(), MediaType.valueOf("application/atom+xml")));
 
         assertEquals(405, result.getStatus());
     }
@@ -522,12 +532,12 @@ class CollectionResourceImplIntegrationTest {
     FileBasedConfiguration getProperties(Path path) throws ConfigurationException {
         var params = new Parameters();
         var paramConfig = params.properties()
-            .setFileName(path.resolve("deposit.properties")
-                .toString());
+                .setFileName(path.resolve("deposit.properties")
+                        .toString());
 
         var builder = new FileBasedConfigurationBuilder<FileBasedConfiguration>(
-            PropertiesConfiguration.class, null, true).configure(
-            paramConfig);
+                PropertiesConfiguration.class, null, true).configure(
+                paramConfig);
 
         return builder.getConfiguration();
     }
@@ -537,6 +547,6 @@ class CollectionResourceImplIntegrationTest {
         md.update(parts);
 
         return DatatypeConverter.printHexBinary(md.digest())
-            .toLowerCase(Locale.ROOT);
+                .toLowerCase(Locale.ROOT);
     }
 }

--- a/src/test/java/nl/knaw/dans/sword2/resources/CollectionResourceLimitedDiskSpaceIntegrationTest.java
+++ b/src/test/java/nl/knaw/dans/sword2/resources/CollectionResourceLimitedDiskSpaceIntegrationTest.java
@@ -21,6 +21,7 @@ import io.dropwizard.testing.junit5.DropwizardAppExtension;
 import io.dropwizard.testing.junit5.DropwizardExtensionsSupport;
 import nl.knaw.dans.sword2.DdSword2Application;
 import nl.knaw.dans.sword2.DdSword2Configuration;
+import nl.knaw.dans.sword2.TestFixture;
 import nl.knaw.dans.sword2.core.service.FileServiceImpl;
 import org.apache.commons.io.FileUtils;
 import org.glassfish.jersey.media.multipart.MultiPartFeature;
@@ -34,12 +35,12 @@ import javax.ws.rs.client.Invocation;
 import javax.ws.rs.core.MediaType;
 import java.io.IOException;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @ExtendWith(DropwizardExtensionsSupport.class)
-class CollectionResourceLimitedDiskSpaceIntegrationTest {
-
+class CollectionResourceLimitedDiskSpaceIntegrationTest extends TestFixture {
     private final DropwizardAppExtension<DdSword2Configuration> EXT = new DropwizardAppExtension<>(
         DdSword2Application.class,
         ResourceHelpers.resourceFilePath("test-etc/config-bigmargin.yml")
@@ -47,12 +48,11 @@ class CollectionResourceLimitedDiskSpaceIntegrationTest {
 
     @BeforeEach
     void startUp() throws IOException {
-        new FileServiceImpl().ensureDirectoriesExist(Path.of("data/tmp/1"));
+        new FileServiceImpl().ensureDirectoriesExist(testDir.resolve("1"));
     }
 
     @AfterEach
     void tearDown() throws IOException {
-        FileUtils.deleteDirectory(Path.of("data/tmp").toFile());
         ((LoggerContext)org.slf4j.LoggerFactory.getILoggerFactory()).stop();
     }
 

--- a/src/test/java/nl/knaw/dans/sword2/resources/CollectionResourceLimitedDiskSpaceIntegrationTest.java
+++ b/src/test/java/nl/knaw/dans/sword2/resources/CollectionResourceLimitedDiskSpaceIntegrationTest.java
@@ -22,6 +22,7 @@ import io.dropwizard.testing.junit5.DropwizardExtensionsSupport;
 import nl.knaw.dans.sword2.DdSword2Application;
 import nl.knaw.dans.sword2.DdSword2Configuration;
 import nl.knaw.dans.sword2.TestFixture;
+import nl.knaw.dans.sword2.TestFixtureExt;
 import nl.knaw.dans.sword2.core.service.FileServiceImpl;
 import org.apache.commons.io.FileUtils;
 import org.glassfish.jersey.media.multipart.MultiPartFeature;
@@ -40,11 +41,10 @@ import java.nio.file.Paths;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @ExtendWith(DropwizardExtensionsSupport.class)
-class CollectionResourceLimitedDiskSpaceIntegrationTest extends TestFixture {
-    private final DropwizardAppExtension<DdSword2Configuration> EXT = new DropwizardAppExtension<>(
-        DdSword2Application.class,
-        ResourceHelpers.resourceFilePath("test-etc/config-bigmargin.yml")
-    );
+class CollectionResourceLimitedDiskSpaceIntegrationTest extends TestFixtureExt {
+    public CollectionResourceLimitedDiskSpaceIntegrationTest() {
+        super("test-etc/config-bigmargin.yml");
+    }
 
     @BeforeEach
     void startUp() throws IOException {
@@ -52,8 +52,8 @@ class CollectionResourceLimitedDiskSpaceIntegrationTest extends TestFixture {
     }
 
     @AfterEach
-    void tearDown() throws IOException {
-        ((LoggerContext)org.slf4j.LoggerFactory.getILoggerFactory()).stop();
+    void tearDown() {
+        ((LoggerContext) org.slf4j.LoggerFactory.getILoggerFactory()).stop();
     }
 
     @Test

--- a/src/test/java/nl/knaw/dans/sword2/resources/ServiceDocumentResourceImplIntegrationTest.java
+++ b/src/test/java/nl/knaw/dans/sword2/resources/ServiceDocumentResourceImplIntegrationTest.java
@@ -21,6 +21,7 @@ import io.dropwizard.testing.junit5.DropwizardAppExtension;
 import io.dropwizard.testing.junit5.DropwizardExtensionsSupport;
 import nl.knaw.dans.sword2.DdSword2Application;
 import nl.knaw.dans.sword2.DdSword2Configuration;
+import nl.knaw.dans.sword2.TestFixtureExt;
 import nl.knaw.dans.sword2.api.service.ServiceDocument;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
@@ -33,12 +34,11 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
 @ExtendWith(DropwizardExtensionsSupport.class)
-class ServiceDocumentResourceImplIntegrationTest {
+class ServiceDocumentResourceImplIntegrationTest extends TestFixtureExt {
 
-    private DropwizardAppExtension<DdSword2Configuration> EXT = new DropwizardAppExtension<>(
-        DdSword2Application.class,
-        ResourceHelpers.resourceFilePath("test-etc/config-servicedocument.yml")
-    );
+    public ServiceDocumentResourceImplIntegrationTest() {
+        super("test-etc/config-servicedocument.yml");
+    }
 
     @AfterEach
     void tearDown() {

--- a/src/test/java/nl/knaw/dans/sword2/resources/StatementResourceImplIntegrationTest.java
+++ b/src/test/java/nl/knaw/dans/sword2/resources/StatementResourceImplIntegrationTest.java
@@ -24,6 +24,7 @@ import io.dropwizard.testing.junit5.DropwizardExtensionsSupport;
 import nl.knaw.dans.sword2.DdSword2Application;
 import nl.knaw.dans.sword2.DdSword2Configuration;
 import nl.knaw.dans.sword2.TestFixture;
+import nl.knaw.dans.sword2.TestFixtureExt;
 import nl.knaw.dans.sword2.api.statement.Feed;
 import nl.knaw.dans.sword2.core.Deposit;
 import nl.knaw.dans.sword2.core.DepositState;
@@ -45,11 +46,11 @@ import java.util.Collections;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @ExtendWith(DropwizardExtensionsSupport.class)
-class StatementResourceImplIntegrationTest extends TestFixture {
-    private final DropwizardAppExtension<DdSword2Configuration> EXT = new DropwizardAppExtension<>(
-        DdSword2Application.class,
-        ResourceHelpers.resourceFilePath("test-etc/config-regular.yml"),
-        new SubstitutingSourceProvider(new FileConfigurationSourceProvider(), new StringSubstitutor(Collections.singletonMap("TEST_DIR", testDir.toString()))));
+class StatementResourceImplIntegrationTest extends TestFixtureExt {
+
+    public StatementResourceImplIntegrationTest() {
+        super("test-etc/config-regular.yml");
+    }
 
     @BeforeEach
     void setUp() throws IOException {
@@ -58,7 +59,7 @@ class StatementResourceImplIntegrationTest extends TestFixture {
     }
 
     @AfterEach
-    void tearDown() throws IOException {
+    void tearDown() {
         ((LoggerContext) org.slf4j.LoggerFactory.getILoggerFactory()).stop();
     }
 

--- a/src/test/java/nl/knaw/dans/sword2/resources/StatementResourceImplIntegrationTest.java
+++ b/src/test/java/nl/knaw/dans/sword2/resources/StatementResourceImplIntegrationTest.java
@@ -21,6 +21,7 @@ import io.dropwizard.testing.junit5.DropwizardAppExtension;
 import io.dropwizard.testing.junit5.DropwizardExtensionsSupport;
 import nl.knaw.dans.sword2.DdSword2Application;
 import nl.knaw.dans.sword2.DdSword2Configuration;
+import nl.knaw.dans.sword2.TestFixture;
 import nl.knaw.dans.sword2.api.statement.Feed;
 import nl.knaw.dans.sword2.core.Deposit;
 import nl.knaw.dans.sword2.core.DepositState;
@@ -35,28 +36,28 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @ExtendWith(DropwizardExtensionsSupport.class)
-class StatementResourceImplIntegrationTest {
-
-    private DropwizardAppExtension<DdSword2Configuration> EXT = new DropwizardAppExtension<>(
+class StatementResourceImplIntegrationTest extends TestFixture {
+    private final DropwizardAppExtension<DdSword2Configuration> EXT = new DropwizardAppExtension<>(
         DdSword2Application.class,
         ResourceHelpers.resourceFilePath("test-etc/config-regular.yml")
     );
 
     @BeforeEach
     void setUp() throws IOException {
-        FileUtils.deleteDirectory(Path.of("data/tmp").toFile());
-        new FileServiceImpl().ensureDirectoriesExist(Path.of("data/tmp/1"));
+        FileUtils.deleteDirectory(testDir.toFile());
+        new FileServiceImpl().ensureDirectoriesExist(testDir.resolve("1"));
     }
 
     @AfterEach
     void tearDown() throws IOException {
-        FileUtils.deleteDirectory(Path.of("data/tmp").toFile());
+        FileUtils.deleteDirectory(testDir.toFile());
         ((LoggerContext) org.slf4j.LoggerFactory.getILoggerFactory()).stop();
     }
 
@@ -69,7 +70,7 @@ class StatementResourceImplIntegrationTest {
         deposit.setStateDescription("Submitted");
         deposit.setDepositor("user001");
 
-        new DepositPropertiesManagerImpl().saveProperties(Path.of("data/tmp/1/deposits/a03ca6f1-608b-4247-8c22-99681b8494a0"), deposit);
+        new DepositPropertiesManagerImpl().saveProperties(testDir.resolve("1/deposits/a03ca6f1-608b-4247-8c22-99681b8494a0"), deposit);
 
         var url = String.format("http://localhost:%s/statement/a03ca6f1-608b-4247-8c22-99681b8494a0", EXT.getLocalPort());
         var response = EXT.client()
@@ -110,7 +111,7 @@ class StatementResourceImplIntegrationTest {
         deposit.setStateDescription("Submitted");
         deposit.setDepositor("user001");
 
-        new DepositPropertiesManagerImpl().saveProperties(Path.of("data/tmp/1/deposits/a03ca6f1-608b-4247-8c22-99681b8494a0/subfolder"), deposit);
+        new DepositPropertiesManagerImpl().saveProperties(testDir.resolve("/1/deposits/a03ca6f1-608b-4247-8c22-99681b8494a0/subfolder"), deposit);
 
         var url = String.format("http://localhost:%s/statement/a03ca6f1-608b-4247-8c22-99681b8494a0", EXT.getLocalPort());
         var response = EXT.client()
@@ -134,7 +135,7 @@ class StatementResourceImplIntegrationTest {
         deposit.setStateDescription("Submitted");
         deposit.setDepositor("user001");
 
-        new DepositPropertiesManagerImpl().saveProperties(Path.of("data/tmp/1/outbox/3/a03ca6f1-608b-4247-8c22-99681b8494a0"), deposit);
+        new DepositPropertiesManagerImpl().saveProperties(testDir.resolve("1/outbox/3/a03ca6f1-608b-4247-8c22-99681b8494a0"), deposit);
 
         var url = String.format("http://localhost:%s/statement/a03ca6f1-608b-4247-8c22-99681b8494a0", EXT.getLocalPort());
         var response = EXT.client()

--- a/src/test/resources/test-etc/config-bagsender.yml
+++ b/src/test/resources/test-etc/config-bagsender.yml
@@ -26,10 +26,10 @@ sword2:
   collections:
     - name: 'collection1'
       path: '1'
-      uploads: $TEST_DIR/bagsender/uploads
-      deposits: $TEST_DIR/bagsender/deposits
+      uploads: ${TEST_DIR}/bagsender/uploads
+      deposits: ${TEST_DIR}/bagsender/deposits
       depositTrackingPath:
-        - $TEST_DIR/bagsender/outbox/failed
+        - ${TEST_DIR}/bagsender/outbox/failed
       autoClean:
         - REJECTED
         - INVALID

--- a/src/test/resources/test-etc/config-bagsender.yml
+++ b/src/test/resources/test-etc/config-bagsender.yml
@@ -26,10 +26,10 @@ sword2:
   collections:
     - name: 'collection1'
       path: '1'
-      uploads: target/test/CollectionResourceBagSenderIntegrationTest/bagsender/uploads
-      deposits: target/test/CollectionResourceBagSenderIntegrationTest/bagsender/deposits
+      uploads: $TEST_DIR/bagsender/uploads
+      deposits: $TEST_DIR/bagsender/deposits
       depositTrackingPath:
-        - target/test/CollectionResourceBagSenderIntegrationTest/bagsender/outbox/failed
+        - $TEST_DIR/bagsender/outbox/failed
       autoClean:
         - REJECTED
         - INVALID

--- a/src/test/resources/test-etc/config-bagsender.yml
+++ b/src/test/resources/test-etc/config-bagsender.yml
@@ -26,10 +26,10 @@ sword2:
   collections:
     - name: 'collection1'
       path: '1'
-      uploads: data/tmp/bagsender/uploads
-      deposits: data/tmp/bagsender/deposits
+      uploads: target/test/CollectionResourceBagSenderIntegrationTest/bagsender/uploads
+      deposits: target/test/CollectionResourceBagSenderIntegrationTest/bagsender/deposits
       depositTrackingPath:
-        - data/tmp/bagsender/outbox/failed
+        - target/test/CollectionResourceBagSenderIntegrationTest/bagsender/outbox/failed
       autoClean:
         - REJECTED
         - INVALID

--- a/src/test/resources/test-etc/config-bigmargin.yml
+++ b/src/test/resources/test-etc/config-bigmargin.yml
@@ -26,10 +26,10 @@ sword2:
   collections:
     - name: 'collection1'
       path: '1'
-      uploads: $TEST_DIR/1/uploads
-      deposits: $TEST_DIR/1/deposits
+      uploads: ${TEST_DIR}/1/uploads
+      deposits: ${TEST_DIR}/1/deposits
       depositTrackingPath:
-        - $TEST_DIR/outbox/failed
+        - ${TEST_DIR}/outbox/failed
       autoClean:
         - REJECTED
       diskSpaceMargin: 200000G

--- a/src/test/resources/test-etc/config-bigmargin.yml
+++ b/src/test/resources/test-etc/config-bigmargin.yml
@@ -26,10 +26,10 @@ sword2:
   collections:
     - name: 'collection1'
       path: '1'
-      uploads: target/test/CollectionResourceLimitedDiskSpaceIntegrationTest/1/uploads
-      deposits: target/test/CollectionResourceLimitedDiskSpaceIntegrationTest/1/deposits
+      uploads: $TEST_DIR/1/uploads
+      deposits: $TEST_DIR/1/deposits
       depositTrackingPath:
-        - target/test/CollectionResourceLimitedDiskSpaceIntegrationTest/outbox/failed
+        - $TEST_DIR/outbox/failed
       autoClean:
         - REJECTED
       diskSpaceMargin: 200000G

--- a/src/test/resources/test-etc/config-bigmargin.yml
+++ b/src/test/resources/test-etc/config-bigmargin.yml
@@ -26,10 +26,10 @@ sword2:
   collections:
     - name: 'collection1'
       path: '1'
-      uploads: data/tmp/1/uploads
-      deposits: data/tmp/1/deposits
+      uploads: target/test/CollectionResourceLimitedDiskSpaceIntegrationTest/1/uploads
+      deposits: target/test/CollectionResourceLimitedDiskSpaceIntegrationTest/1/deposits
       depositTrackingPath:
-        - data/tmp/1/outbox/failed
+        - target/test/CollectionResourceLimitedDiskSpaceIntegrationTest/outbox/failed
       autoClean:
         - REJECTED
       diskSpaceMargin: 200000G

--- a/src/test/resources/test-etc/config-regular.yml
+++ b/src/test/resources/test-etc/config-regular.yml
@@ -25,23 +25,23 @@ sword2:
   collections:
     - name: 'collection1'
       path: '1'
-      uploads: data/tmp/1/uploads
-      deposits: data/tmp/1/deposits
+      uploads: ${TEST_DIR}/1/uploads
+      deposits: ${TEST_DIR}/1/deposits
       depositTrackingPath:
-        - data/tmp/1/outbox/1
-        - data/tmp/1/outbox/2
-        - data/tmp/1/outbox/3
+        - ${TEST_DIR}/1/outbox/1
+        - ${TEST_DIR}/1/outbox/2
+        - ${TEST_DIR}/1/outbox/3
       autoClean:
         - INVALID
       diskSpaceMargin: 2G
     - name: 'collection2'
       path: '2'
-      uploads: data/tmp/2/uploads
-      deposits: data/tmp/2/deposits
+      uploads: ${TEST_DIR}/2/uploads
+      deposits: ${TEST_DIR}/2/deposits
       depositTrackingPath:
-        - data/tmp/2/outbox/1
-        - data/tmp/2/outbox/2
-        - data/tmp/2/outbox/3
+        - ${TEST_DIR}/2/outbox/1
+        - ${TEST_DIR}/2/outbox/2
+        - ${TEST_DIR}/2/outbox/3
       autoClean:
         - INVALID
       diskSpaceMargin: 2G

--- a/src/test/resources/test-etc/config-regular.yml
+++ b/src/test/resources/test-etc/config-regular.yml
@@ -25,23 +25,23 @@ sword2:
   collections:
     - name: 'collection1'
       path: '1'
-      uploads: $TEST_DIR/1/uploads
-      deposits: $TEST_DIR/1/deposits
+      uploads: ${TEST_DIR}/1/uploads
+      deposits: ${TEST_DIR}/1/deposits
       depositTrackingPath:
-        - $TEST_DIR/1/outbox/1
-        - $TEST_DIR/1/outbox/2
-        - $TEST_DIR/1/outbox/3
+        - ${TEST_DIR}/1/outbox/1
+        - ${TEST_DIR}/1/outbox/2
+        - ${TEST_DIR}/1/outbox/3
       autoClean:
         - INVALID
       diskSpaceMargin: 2G
     - name: 'collection2'
       path: '2'
-      uploads: $TEST_DIR/2/uploads
-      deposits: $TEST_DIR/2/deposits
+      uploads: ${TEST_DIR}/2/uploads
+      deposits: ${TEST_DIR}/2/deposits
       depositTrackingPath:
-        - $TEST_DIR/2/outbox/1
-        - $TEST_DIR/2/outbox/2
-        - $TEST_DIR/2/outbox/3
+        - ${TEST_DIR}/2/outbox/1
+        - ${TEST_DIR}/2/outbox/2
+        - ${TEST_DIR}/2/outbox/3
       autoClean:
         - INVALID
       diskSpaceMargin: 2G

--- a/src/test/resources/test-etc/config-regular.yml
+++ b/src/test/resources/test-etc/config-regular.yml
@@ -25,23 +25,23 @@ sword2:
   collections:
     - name: 'collection1'
       path: '1'
-      uploads: ${TEST_DIR}/1/uploads
-      deposits: ${TEST_DIR}/1/deposits
+      uploads: $TEST_DIR/1/uploads
+      deposits: $TEST_DIR/1/deposits
       depositTrackingPath:
-        - ${TEST_DIR}/1/outbox/1
-        - ${TEST_DIR}/1/outbox/2
-        - ${TEST_DIR}/1/outbox/3
+        - $TEST_DIR/1/outbox/1
+        - $TEST_DIR/1/outbox/2
+        - $TEST_DIR/1/outbox/3
       autoClean:
         - INVALID
       diskSpaceMargin: 2G
     - name: 'collection2'
       path: '2'
-      uploads: ${TEST_DIR}/2/uploads
-      deposits: ${TEST_DIR}/2/deposits
+      uploads: $TEST_DIR/2/uploads
+      deposits: $TEST_DIR/2/deposits
       depositTrackingPath:
-        - ${TEST_DIR}/2/outbox/1
-        - ${TEST_DIR}/2/outbox/2
-        - ${TEST_DIR}/2/outbox/3
+        - $TEST_DIR/2/outbox/1
+        - $TEST_DIR/2/outbox/2
+        - $TEST_DIR/2/outbox/3
       autoClean:
         - INVALID
       diskSpaceMargin: 2G

--- a/src/test/resources/test-etc/config-servicedocument.yml
+++ b/src/test/resources/test-etc/config-servicedocument.yml
@@ -27,19 +27,19 @@ sword2:
   collections:
     - name: 'collection1'
       path: '1'
-      uploads: $TEST_DIR/1/uploads
-      deposits: $TEST_DIR/1/deposits
+      uploads: ${TEST_DIR}/1/uploads
+      deposits: ${TEST_DIR}/1/deposits
       depositTrackingPath:
-        - $TEST_DIR/outbox/failed
+        - ${TEST_DIR}/outbox/failed
       autoClean:
         - REJECTED
       diskSpaceMargin: 2G
     - name: 'collection2'
       path: '2'
-      uploads: $TEST_DIR/2/uploads
-      deposits: $TEST_DIR/2/deposits
+      uploads: ${TEST_DIR}/2/uploads
+      deposits: ${TEST_DIR}/2/deposits
       depositTrackingPath:
-        - $TEST_DIR/outbox/failed
+        - ${TEST_DIR}/outbox/failed
       autoClean:
         - REJECTED
       diskSpaceMargin: 2G

--- a/src/test/resources/test-etc/config-servicedocument.yml
+++ b/src/test/resources/test-etc/config-servicedocument.yml
@@ -27,19 +27,19 @@ sword2:
   collections:
     - name: 'collection1'
       path: '1'
-      uploads: data/tmp/1/uploads
-      deposits: data/tmp/1/deposits
+      uploads: $TEST_DIR/1/uploads
+      deposits: $TEST_DIR/1/deposits
       depositTrackingPath:
-        - data/tmp/1/outbox/failed
+        - $TEST_DIR/outbox/failed
       autoClean:
         - REJECTED
       diskSpaceMargin: 2G
     - name: 'collection2'
       path: '2'
-      uploads: data/tmp/2/uploads
-      deposits: data/tmp/2/deposits
+      uploads: $TEST_DIR/2/uploads
+      deposits: $TEST_DIR/2/deposits
       depositTrackingPath:
-        - data/tmp/2/outbox/failed
+        - $TEST_DIR/outbox/failed
       autoClean:
         - REJECTED
       diskSpaceMargin: 2G


### PR DESCRIPTION
Fixes DD-1178

# Description of changes
The `dd-sword2` service did not make a proper distinction between an invalid deposit and a corrupted one. An invalid deposit is a problem caused by the client by sending faulty checksums in the bag. A corrupted deposit is a server error and should therefore lead to a 500 error. The problem was easily solved by removing a exception handler that caught `Throwable` (which I think should have been a narrower exception anyway) and letting the type of problem result naturally in a 500 Internal Server Error.

When testing this I found out that many tests were using the `data` folder under the project root directory as a space to work in. This was never my intent. I will document that in `dans-module-archetype`. In short: the `data/` folder is for trying things out when working with dans-dev-tools. Unit tests should work under `target/test`. When refactoring these test I had to find a way to point to the test directory from the `config.yml` files used in the test. This was resolved using a `SubstitutingSourceProvider` that uses a `StringSubstitutor` to dereference the variable `TEST_DIR` in the `config.yml`.

# How to test

1. Start the service with `start-service.sh` 
2. Deposit a bag
3. Make the bag corrupt by removing read permissions on the bag for all users.
4. Request the statement

Before the fix a statement was returned with the state INVALID, after the fix a 500 error results.


# Notify
@DANS-KNAW/dataversedans
