### PR TITLE
Fix bug with InvalidDepositExceptions not propagating error messages

### DIFF
--- a/src/main/java/nl/knaw/dans/sword2/core/service/BagExtractorImpl.java
+++ b/src/main/java/nl/knaw/dans/sword2/core/service/BagExtractorImpl.java
@@ -88,22 +88,23 @@ public class BagExtractorImpl implements BagExtractor {
 
     int getSequenceNumber(Path path) throws InvalidPartialFileException {
         var parts = path.getFileName().toString().split("\\.");
+        var fileName = path.getFileName();
 
         if (parts.length <= 1) {
-            throw new InvalidPartialFileException(String.format("Partial file %s has no extension. It should be a positive sequence number.", path));
+            throw new InvalidPartialFileException(String.format("Partial file %s has no extension. It should be a positive sequence number.", fileName));
         }
 
         try {
             var value = Integer.parseInt(parts[parts.length - 1], 10);
 
             if (value <= 0) {
-                throw new InvalidPartialFileException(String.format("Partial file %s has an incorrect extension. It should be a positive sequence number (> 0), but was: %s", path, value));
+                throw new InvalidPartialFileException(String.format("Partial file %s has an incorrect extension. It should be a positive sequence number (> 0), but was: %s", fileName, value));
             }
 
             return value;
         }
         catch (NumberFormatException e) {
-            throw new InvalidPartialFileException(String.format("Partial file %s has an incorrect extension. Should be a positive sequence number.", path));
+            throw new InvalidPartialFileException(String.format("Partial file %s has an incorrect extension. Should be a positive sequence number.", fileName));
         }
     }
 

--- a/src/main/java/nl/knaw/dans/sword2/core/service/DepositHandlerImpl.java
+++ b/src/main/java/nl/knaw/dans/sword2/core/service/DepositHandlerImpl.java
@@ -15,9 +15,9 @@
  */
 package nl.knaw.dans.sword2.core.service;
 
-import nl.knaw.dans.sword2.core.auth.Depositor;
 import nl.knaw.dans.sword2.core.Deposit;
 import nl.knaw.dans.sword2.core.DepositState;
+import nl.knaw.dans.sword2.core.auth.Depositor;
 import nl.knaw.dans.sword2.core.config.CollectionConfig;
 import nl.knaw.dans.sword2.core.exceptions.CollectionNotFoundException;
 import nl.knaw.dans.sword2.core.exceptions.DepositNotFoundException;
@@ -303,11 +303,11 @@ public class DepositHandlerImpl implements DepositHandler {
 
             return deposit;
         }
-        catch (InvalidDepositException e) {
+        catch (InvalidDepositException | InvalidPartialFileException e) {
             setDepositToInvalid(depositId, e.getMessage());
             throw e;
         }
-        catch (InvalidPartialFileException | CollectionNotFoundException e) {
+        catch (CollectionNotFoundException e) {
             setDepositToFailed(depositId, getGenericErrorMessage(depositId));
             throw e;
         }

--- a/src/main/java/nl/knaw/dans/sword2/resources/CollectionResourceImpl.java
+++ b/src/main/java/nl/knaw/dans/sword2/resources/CollectionResourceImpl.java
@@ -74,7 +74,6 @@ public class CollectionResourceImpl extends BaseResource implements CollectionRe
         try {
             var contentType = getContentType(headers.getHeaderString("content-type"));
             var inProgress = getInProgress(headers.getHeaderString("in-progress"));
-
             var contentDisposition = headers.getHeaderString("content-disposition");
             var md5 = headers.getHeaderString("content-md5");
             var packaging = getPackaging(headers.getHeaderString("packaging"));

--- a/src/test/java/nl/knaw/dans/sword2/core/service/BagExtractorImplTest.java
+++ b/src/test/java/nl/knaw/dans/sword2/core/service/BagExtractorImplTest.java
@@ -247,7 +247,7 @@ class BagExtractorImplTest extends TestFixture {
     }
 
     @Test
-    void testIncorrectNumberZero() throws InvalidPartialFileException {
+    void testIncorrectNumberZero() {
         var path = Path.of("test.0");
         assertThrows(InvalidPartialFileException.class, () -> new BagExtractorImpl(zipService, fileService, bagItManager, filesystemSpaceVerifier).getSequenceNumber(path));
     }
@@ -262,6 +262,15 @@ class BagExtractorImplTest extends TestFixture {
     void testNonNumericalExtension() throws InvalidPartialFileException {
         var path = Path.of("test.zip1");
         assertThrows(InvalidPartialFileException.class, () -> new BagExtractorImpl(zipService, fileService, bagItManager, filesystemSpaceVerifier).getSequenceNumber(path));
+    }
+
+    @Test
+    void getSequenceNumber_should_throw_error_with_00_suffix() throws InvalidPartialFileException {
+        var path = Path.of("test.zip.00");
+        var e = assertThrows(InvalidPartialFileException.class,
+            () -> new BagExtractorImpl(zipService, fileService, bagItManager, filesystemSpaceVerifier).getSequenceNumber(path));
+
+        assertTrue(e.getMessage().contains("It should be a positive sequence number (> 0)"));
     }
 
     @Test

--- a/src/test/java/nl/knaw/dans/sword2/resources/CollectionResourceImplIntegrationTest.java
+++ b/src/test/java/nl/knaw/dans/sword2/resources/CollectionResourceImplIntegrationTest.java
@@ -249,7 +249,7 @@ class CollectionResourceImplIntegrationTest extends TestFixtureExt {
 
         assertEquals("SUBMITTED", state);
 
-        var firstPath = testDir.resolve("1/uploads/").resolve(id);
+        var firstPath = testDir.resolve("1/deposits/").resolve(id);
         assertTrue(Files.exists(firstPath.resolve("deposit.properties")));
         assertTrue(Files.exists(firstPath.resolve("audiences/bagit.txt")));
         assertFalse(Files.exists(firstPath.resolve("bag.zip.1")));

--- a/src/test/java/nl/knaw/dans/sword2/resources/CollectionResourceImplIntegrationTest.java
+++ b/src/test/java/nl/knaw/dans/sword2/resources/CollectionResourceImplIntegrationTest.java
@@ -16,17 +16,7 @@
 package nl.knaw.dans.sword2.resources;
 
 import ch.qos.logback.classic.LoggerContext;
-import io.dropwizard.configuration.ConfigurationSourceProvider;
-import io.dropwizard.configuration.FileConfigurationSourceProvider;
-import io.dropwizard.configuration.ResourceConfigurationSourceProvider;
-import io.dropwizard.configuration.SubstitutingSourceProvider;
-import io.dropwizard.testing.ConfigOverride;
-import io.dropwizard.testing.ResourceHelpers;
-import io.dropwizard.testing.junit5.DropwizardAppExtension;
 import io.dropwizard.testing.junit5.DropwizardExtensionsSupport;
-import nl.knaw.dans.sword2.DdSword2Application;
-import nl.knaw.dans.sword2.DdSword2Configuration;
-import nl.knaw.dans.sword2.TestFixture;
 import nl.knaw.dans.sword2.TestFixtureExt;
 import nl.knaw.dans.sword2.api.entry.Entry;
 import nl.knaw.dans.sword2.api.error.Error;
@@ -38,7 +28,6 @@ import org.apache.commons.configuration2.builder.FileBasedConfigurationBuilder;
 import org.apache.commons.configuration2.builder.fluent.Parameters;
 import org.apache.commons.configuration2.ex.ConfigurationException;
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.text.StringSubstitutor;
 import org.glassfish.jersey.media.multipart.BodyPart;
 import org.glassfish.jersey.media.multipart.MultiPart;
 import org.glassfish.jersey.media.multipart.MultiPartFeature;
@@ -55,11 +44,9 @@ import javax.xml.bind.JAXBException;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.Locale;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -74,7 +61,6 @@ class CollectionResourceImplIntegrationTest extends TestFixtureExt {
     public CollectionResourceImplIntegrationTest() {
         super("test-etc/config-regular.yml");
     }
-
 
     @BeforeEach
     void startUp() throws IOException {
@@ -91,10 +77,10 @@ class CollectionResourceImplIntegrationTest extends TestFixtureExt {
         var url = String.format("http://localhost:%s%s", EXT.getLocalPort(), path);
 
         return RequestClientBuilder.buildClient()
-                .target(url)
-                .register(MultiPartFeature.class)
-                .request()
-                .header("authorization", "Basic dXNlcjAwMTp1c2VyMDAx");
+            .target(url)
+            .register(MultiPartFeature.class)
+            .request()
+            .header("authorization", "Basic dXNlcjAwMTp1c2VyMDAx");
     }
 
     @Test
@@ -104,17 +90,17 @@ class CollectionResourceImplIntegrationTest extends TestFixtureExt {
         assert path != null;
 
         var result = buildRequest("/collection/1")
-                .header("content-type", "application/zip")
-                .header("content-md5", "bc27e20467a773501a4ae37fb85a9c3f")
-                .header("content-disposition", "attachment; filename=bag.zip")
-                .header("in-progress", "true")
-                .post(Entity.entity(path.openStream(), MediaType.valueOf("application/zip")));
+            .header("content-type", "application/zip")
+            .header("content-md5", "bc27e20467a773501a4ae37fb85a9c3f")
+            .header("content-disposition", "attachment; filename=bag.zip")
+            .header("in-progress", "true")
+            .post(Entity.entity(path.openStream(), MediaType.valueOf("application/zip")));
 
         assertEquals(201, result.getStatus());
 
         var receipt = result.readEntity(Entry.class);
         var parts = receipt.getId()
-                .split("/");
+            .split("/");
         var id = parts[parts.length - 1];
 
         var firstPath = testDir.resolve("1/uploads/").resolve(id);
@@ -133,7 +119,7 @@ class CollectionResourceImplIntegrationTest extends TestFixtureExt {
         assertEquals("Deposit is open for additional data", config.getString("state.description"));
 
         var statusResult = buildRequest("/statement/" + id)
-                .get();
+            .get();
 
         var feed = statusResult.readEntity(Feed.class);
         assertEquals("http://localhost:20320/statement/" + id, feed.getId());
@@ -146,21 +132,21 @@ class CollectionResourceImplIntegrationTest extends TestFixtureExt {
         assert path != null;
 
         var result = buildRequest("/collection/1")
-                .header("content-type", "application/zip")
-                .header("content-md5", "bc27e20467a773501a4ae37fb85a9c3f")
-                .header("content-disposition", "attachment; filename=bag.zip")
-                .header("in-progress", "true")
-                .post(Entity.entity(path.openStream(), MediaType.valueOf("application/zip")));
+            .header("content-type", "application/zip")
+            .header("content-md5", "bc27e20467a773501a4ae37fb85a9c3f")
+            .header("content-disposition", "attachment; filename=bag.zip")
+            .header("in-progress", "true")
+            .post(Entity.entity(path.openStream(), MediaType.valueOf("application/zip")));
 
         assertEquals(201, result.getStatus());
 
         var receipt = result.readEntity(Entry.class);
         var parts = receipt.getId()
-                .split("/");
+            .split("/");
         var id = parts[parts.length - 1];
 
         var statusResult = buildRequest("/container/" + id)
-                .get();
+            .get();
 
         var feed = statusResult.readEntity(Entry.class);
         assertEquals("http://localhost:20320/container/" + id, feed.getId());
@@ -173,21 +159,21 @@ class CollectionResourceImplIntegrationTest extends TestFixtureExt {
         assert path != null;
 
         var result = buildRequest("/collection/1")
-                .header("content-type", "application/zip")
-                .header("content-md5", "bc27e20467a773501a4ae37fb85a9c3f")
-                .header("content-disposition", "attachment; filename=bag.zip")
-                .header("in-progress", "true")
-                .post(Entity.entity(path.openStream(), MediaType.valueOf("application/zip")));
+            .header("content-type", "application/zip")
+            .header("content-md5", "bc27e20467a773501a4ae37fb85a9c3f")
+            .header("content-disposition", "attachment; filename=bag.zip")
+            .header("in-progress", "true")
+            .post(Entity.entity(path.openStream(), MediaType.valueOf("application/zip")));
 
         assertEquals(201, result.getStatus());
 
         var receipt = result.readEntity(Entry.class);
         var parts = receipt.getId()
-                .split("/");
+            .split("/");
         var id = parts[parts.length - 1];
 
         var statusResult = buildRequest("/container/" + id)
-                .head();
+            .head();
 
         assertEquals(200, statusResult.getStatus());
         assertEquals("http://localhost:20320/container/" + id, statusResult.getHeaderString("location"));
@@ -196,14 +182,14 @@ class CollectionResourceImplIntegrationTest extends TestFixtureExt {
     @Test
     void testDepositReceiptFromContainerEndpointNotFound() {
         var statusResult = buildRequest("/container/" + "random_id")
-                .get();
+            .get();
 
         assertEquals(404, statusResult.getStatus());
     }
 
     @Test
     void testZipInParts() throws
-            IOException, ConfigurationException, NoSuchAlgorithmException, InterruptedException {
+        IOException, ConfigurationException, NoSuchAlgorithmException, InterruptedException {
         var path = getClass().getResource("/zips/audiences.zip");
         assert path != null;
 
@@ -213,11 +199,11 @@ class CollectionResourceImplIntegrationTest extends TestFixtureExt {
 
         var checksum = md5Checksum(firstPart);
         var result = buildRequest("/collection/1")
-                .header("content-type", "application/octet-stream")
-                .header("content-md5", checksum)
-                .header("content-disposition", "attachment; filename=bag.zip.1")
-                .header("in-progress", "true")
-                .post(Entity.entity(firstPart, MediaType.valueOf("application/octet-stream")));
+            .header("content-type", "application/octet-stream")
+            .header("content-md5", checksum)
+            .header("content-disposition", "attachment; filename=bag.zip.1")
+            .header("in-progress", "true")
+            .post(Entity.entity(firstPart, MediaType.valueOf("application/octet-stream")));
 
         assertEquals(201, result.getStatus());
 
@@ -228,22 +214,22 @@ class CollectionResourceImplIntegrationTest extends TestFixtureExt {
         var secondPart = Arrays.copyOfRange(bytes, bagSize, bagSize * 2);
         var checksum2 = md5Checksum(secondPart);
         var result2 = buildRequest("/container/" + id)
-                .header("content-type", "application/octet-stream")
-                .header("content-md5", checksum2)
-                .header("content-disposition", "attachment; filename=bag.zip.2")
-                .header("in-progress", "true")
-                .post(Entity.entity(secondPart, MediaType.valueOf("application/octet-stream")));
+            .header("content-type", "application/octet-stream")
+            .header("content-md5", checksum2)
+            .header("content-disposition", "attachment; filename=bag.zip.2")
+            .header("in-progress", "true")
+            .post(Entity.entity(secondPart, MediaType.valueOf("application/octet-stream")));
         assertEquals(200, result2.getStatus());
 
         var thirdPart = Arrays.copyOfRange(bytes, bagSize * 2, bytes.length);
         var checksum3 = md5Checksum(thirdPart);
 
         var result3 = buildRequest("/container/" + id)
-                .header("content-type", "application/octet-stream")
-                .header("content-md5", checksum3)
-                .header("content-disposition", "attachment; filename=bag.zip.3")
-                .header("in-progress", "false")
-                .post(Entity.entity(thirdPart, MediaType.valueOf("application/zip")));
+            .header("content-type", "application/octet-stream")
+            .header("content-md5", checksum3)
+            .header("content-disposition", "attachment; filename=bag.zip.3")
+            .header("in-progress", "false")
+            .post(Entity.entity(thirdPart, MediaType.valueOf("application/zip")));
         assertEquals(200, result3.getStatus());
 
         var count = 0;
@@ -263,7 +249,7 @@ class CollectionResourceImplIntegrationTest extends TestFixtureExt {
 
         assertEquals("SUBMITTED", state);
 
-        var firstPath = testDir.resolve("1/deposits/").resolve(id);
+        var firstPath = testDir.resolve("1/uploads/").resolve(id);
         assertTrue(Files.exists(firstPath.resolve("deposit.properties")));
         assertTrue(Files.exists(firstPath.resolve("audiences/bagit.txt")));
         assertFalse(Files.exists(firstPath.resolve("bag.zip.1")));
@@ -273,7 +259,7 @@ class CollectionResourceImplIntegrationTest extends TestFixtureExt {
 
     @Test
     void testZipInPartsWithInvalidHash() throws
-            IOException, ConfigurationException, NoSuchAlgorithmException, InterruptedException {
+        IOException, ConfigurationException, NoSuchAlgorithmException, InterruptedException {
         var path = getClass().getResource("/zips/audiences.zip");
         assert path != null;
 
@@ -283,11 +269,11 @@ class CollectionResourceImplIntegrationTest extends TestFixtureExt {
 
         var checksum = md5Checksum(firstPart);
         var result = buildRequest("/collection/1")
-                .header("content-type", "application/octet-stream")
-                .header("content-md5", checksum)
-                .header("content-disposition", "attachment; filename=bag.zip.1")
-                .header("in-progress", "true")
-                .post(Entity.entity(firstPart, MediaType.valueOf("application/octet-stream")));
+            .header("content-type", "application/octet-stream")
+            .header("content-md5", checksum)
+            .header("content-disposition", "attachment; filename=bag.zip.1")
+            .header("in-progress", "true")
+            .post(Entity.entity(firstPart, MediaType.valueOf("application/octet-stream")));
 
         assertEquals(201, result.getStatus());
 
@@ -298,22 +284,22 @@ class CollectionResourceImplIntegrationTest extends TestFixtureExt {
         var secondPart = Arrays.copyOfRange(bytes, bagSize, bagSize * 2);
         var checksum2 = md5Checksum(secondPart);
         var result2 = buildRequest("/container/" + id)
-                .header("content-type", "application/octet-stream")
-                .header("content-md5", checksum2)
-                .header("content-disposition", "attachment; filename=bag.zip.2")
-                .header("in-progress", "true")
-                .post(Entity.entity(secondPart, MediaType.valueOf("application/octet-stream")));
+            .header("content-type", "application/octet-stream")
+            .header("content-md5", checksum2)
+            .header("content-disposition", "attachment; filename=bag.zip.2")
+            .header("in-progress", "true")
+            .post(Entity.entity(secondPart, MediaType.valueOf("application/octet-stream")));
         assertEquals(200, result2.getStatus());
 
         var thirdPart = Arrays.copyOfRange(bytes, bagSize * 2, bytes.length);
         var checksum3 = md5Checksum(thirdPart);
 
         var result3 = buildRequest("/container/" + id)
-                .header("content-type", "application/octet-stream")
-                .header("content-md5", "invalid_checksum")
-                .header("content-disposition", "attachment; filename=bag.zip.3")
-                .header("in-progress", "false")
-                .post(Entity.entity(thirdPart, MediaType.valueOf("application/zip")));
+            .header("content-type", "application/octet-stream")
+            .header("content-md5", "invalid_checksum")
+            .header("content-disposition", "attachment; filename=bag.zip.3")
+            .header("in-progress", "false")
+            .post(Entity.entity(thirdPart, MediaType.valueOf("application/zip")));
         assertEquals(412, result3.getStatus());
 
         var firstPath = testDir.resolve("1/uploads/").resolve(id);
@@ -329,11 +315,11 @@ class CollectionResourceImplIntegrationTest extends TestFixtureExt {
         assert path != null;
 
         var result = buildRequest("/collection/1")
-                .header("content-type", "application/zip")
-                .header("content-md5", "bc27e20467a773501a4ae37fb85a9c3f")
-                .header("in-progress", "false")
-                .header("content-disposition", "attachment; filename=bag.zip")
-                .post(Entity.entity(path.openStream(), MediaType.valueOf("application/zip")));
+            .header("content-type", "application/zip")
+            .header("content-md5", "bc27e20467a773501a4ae37fb85a9c3f")
+            .header("in-progress", "false")
+            .header("content-disposition", "attachment; filename=bag.zip")
+            .post(Entity.entity(path.openStream(), MediaType.valueOf("application/zip")));
 
         assertEquals(201, result.getStatus());
 
@@ -347,10 +333,10 @@ class CollectionResourceImplIntegrationTest extends TestFixtureExt {
         // waiting at most 5 seconds for the background thread to handle this
         while (count < 5) {
             var statement = buildRequest("/statement/" + id)
-                    .get(Feed.class);
+                .get(Feed.class);
 
             state = statement.getCategory()
-                    .getTerm();
+                .getTerm();
 
             if (state.equals("SUBMITTED")) {
                 break;
@@ -382,11 +368,11 @@ class CollectionResourceImplIntegrationTest extends TestFixtureExt {
         assert path != null;
 
         var result = buildRequest("/collection/1")
-                .header("content-type", "application/zip")
-                .header("content-md5", "db45b2cfeb223d35d25a6d5208b528db")
-                .header("in-progress", "false")
-                .header("content-disposition", "attachment; filename=bag.zip")
-                .post(Entity.entity(path.openStream(), MediaType.valueOf("application/zip")));
+            .header("content-type", "application/zip")
+            .header("content-md5", "db45b2cfeb223d35d25a6d5208b528db")
+            .header("in-progress", "false")
+            .header("content-disposition", "attachment; filename=bag.zip")
+            .post(Entity.entity(path.openStream(), MediaType.valueOf("application/zip")));
 
         assertEquals(201, result.getStatus());
 
@@ -400,10 +386,10 @@ class CollectionResourceImplIntegrationTest extends TestFixtureExt {
         // waiting at most 5 seconds for the background thread to handle this
         while (count < 5) {
             var statement = buildRequest("/statement/" + id)
-                    .get(Feed.class);
+                .get(Feed.class);
 
             state = statement.getCategory()
-                    .getTerm();
+                .getTerm();
 
             if (state.equals("INVALID")) {
                 break;
@@ -437,11 +423,11 @@ class CollectionResourceImplIntegrationTest extends TestFixtureExt {
         assert path != null;
 
         var result = buildRequest("/collection/1")
-                .header("content-type", "application/zip")
-                .header("content-md5", "invalid_hash")
-                .header("in-progress", "false")
-                .header("content-disposition", "attachment; filename=bag.zip")
-                .post(Entity.entity(path.openStream(), MediaType.valueOf("application/zip")));
+            .header("content-type", "application/zip")
+            .header("content-md5", "invalid_hash")
+            .header("in-progress", "false")
+            .header("content-disposition", "attachment; filename=bag.zip")
+            .post(Entity.entity(path.openStream(), MediaType.valueOf("application/zip")));
 
         assertEquals(412, result.getStatus());
 
@@ -467,9 +453,9 @@ class CollectionResourceImplIntegrationTest extends TestFixtureExt {
         multiPart.setMediaType(MediaType.valueOf("multipart/related"));
 
         var result = buildRequest("/collection/1")
-                .header("content-length", 1000)
-                .header("in-progress", "true")
-                .post(Entity.entity(multiPart, multiPart.getMediaType()));
+            .header("content-length", 1000)
+            .header("in-progress", "true")
+            .post(Entity.entity(multiPart, multiPart.getMediaType()));
 
         assertEquals(405, result.getStatus());
     }
@@ -481,11 +467,11 @@ class CollectionResourceImplIntegrationTest extends TestFixtureExt {
         assert path != null;
 
         var result = buildRequest("/collection/123")
-                .header("content-type", "application/zip")
-                .header("content-md5", "bc27e20467a773501a4ae37fb85a9c3f")
-                .header("content-disposition", "attachment; filename=bag.zip")
-                .header("in-progress", "true")
-                .post(Entity.entity(path.openStream(), MediaType.valueOf("application/zip")));
+            .header("content-type", "application/zip")
+            .header("content-md5", "bc27e20467a773501a4ae37fb85a9c3f")
+            .header("content-disposition", "attachment; filename=bag.zip")
+            .header("in-progress", "true")
+            .post(Entity.entity(path.openStream(), MediaType.valueOf("application/zip")));
 
         assertEquals(405, result.getStatus());
 
@@ -502,11 +488,11 @@ class CollectionResourceImplIntegrationTest extends TestFixtureExt {
         assert path != null;
 
         var result = buildRequest("/collection/123")
-                .header("content-type", "application/zip")
-                .header("content-md5", "bc27e20467a773501a4ae37fb85a9c3f")
-                .header("content-disposition", "attachment; filename=bag.zip")
-                .header("in-progress", "this is something else")
-                .post(Entity.entity(path.openStream(), MediaType.valueOf("application/zip")));
+            .header("content-type", "application/zip")
+            .header("content-md5", "bc27e20467a773501a4ae37fb85a9c3f")
+            .header("content-disposition", "attachment; filename=bag.zip")
+            .header("in-progress", "this is something else")
+            .post(Entity.entity(path.openStream(), MediaType.valueOf("application/zip")));
 
         assertEquals(400, result.getStatus());
 
@@ -522,23 +508,92 @@ class CollectionResourceImplIntegrationTest extends TestFixtureExt {
         assert path != null;
 
         var result = buildRequest("/collection/1")
-                .header("content-length", 1000)
-                .header("in-progress", "true")
-                .header("content-type", "application/atom+xml")
-                .post(Entity.entity(path.openStream(), MediaType.valueOf("application/atom+xml")));
+            .header("content-length", 1000)
+            .header("in-progress", "true")
+            .header("content-type", "application/atom+xml")
+            .post(Entity.entity(path.openStream(), MediaType.valueOf("application/atom+xml")));
 
         assertEquals(405, result.getStatus());
+    }
+
+    @Test
+    void testZipInParts_should_set_state_to_INVALID_and_give_invalid_sequence_number_reason() throws
+        IOException, ConfigurationException, NoSuchAlgorithmException, InterruptedException {
+        var path = getClass().getResource("/zips/audiences.zip");
+        assert path != null;
+
+        var bytes = path.openStream().readAllBytes();
+        var bagSize = bytes.length / 3;
+        var firstPart = Arrays.copyOfRange(bytes, 0, bagSize);
+
+        var checksum = md5Checksum(firstPart);
+        var result = buildRequest("/collection/1")
+            .header("content-type", "application/octet-stream")
+            .header("content-md5", checksum)
+            .header("content-disposition", "attachment; filename=bag.zip.00")
+            .header("in-progress", "true")
+            .post(Entity.entity(firstPart, MediaType.valueOf("application/octet-stream")));
+
+        assertEquals(201, result.getStatus());
+
+        var receipt = result.readEntity(Entry.class);
+        var parts = receipt.getId().split("/");
+        var id = parts[parts.length - 1];
+
+        var secondPart = Arrays.copyOfRange(bytes, bagSize, bagSize * 2);
+        var checksum2 = md5Checksum(secondPart);
+        var result2 = buildRequest("/container/" + id)
+            .header("content-type", "application/octet-stream")
+            .header("content-md5", checksum2)
+            .header("content-disposition", "attachment; filename=bag.zip.2")
+            .header("in-progress", "true")
+            .post(Entity.entity(secondPart, MediaType.valueOf("application/octet-stream")));
+        assertEquals(200, result2.getStatus());
+
+        var thirdPart = Arrays.copyOfRange(bytes, bagSize * 2, bytes.length);
+        var checksum3 = md5Checksum(thirdPart);
+
+        var result3 = buildRequest("/container/" + id)
+            .header("content-type", "application/octet-stream")
+            .header("content-md5", checksum3)
+            .header("content-disposition", "attachment; filename=bag.zip.3")
+            .header("in-progress", "false")
+            .post(Entity.entity(thirdPart, MediaType.valueOf("application/zip")));
+        assertEquals(200, result3.getStatus());
+
+        var count = 0;
+        var state = "";
+
+        // waiting at most 5 seconds for the background thread to handle this
+        while (count < 5) {
+            var statement = buildRequest("/statement/" + id).get(Feed.class);
+            state = statement.getCategory().getTerm();
+
+            if (state.equals("INVALID")) {
+                break;
+            }
+            Thread.sleep(1000);
+            count += 1;
+        }
+
+        assertEquals("INVALID", state);
+
+        var firstPath = testDir.resolve("1/uploads/").resolve(id);
+        assertTrue(Files.exists(firstPath.resolve("deposit.properties")));
+        assertEquals("Partial file bag.zip.00 has an incorrect extension. It should be a positive sequence number (> 0), but was: 0",
+            getProperties(firstPath).getString("state.description"));
+
     }
 
     FileBasedConfiguration getProperties(Path path) throws ConfigurationException {
         var params = new Parameters();
         var paramConfig = params.properties()
-                .setFileName(path.resolve("deposit.properties")
-                        .toString());
+            .setFileName(path.resolve("deposit.properties")
+                .toString());
 
         var builder = new FileBasedConfigurationBuilder<FileBasedConfiguration>(
-                PropertiesConfiguration.class, null, true).configure(
-                paramConfig);
+            PropertiesConfiguration.class, null, true).configure(
+            paramConfig);
 
         return builder.getConfiguration();
     }
@@ -548,6 +603,6 @@ class CollectionResourceImplIntegrationTest extends TestFixtureExt {
         md.update(parts);
 
         return DatatypeConverter.printHexBinary(md.digest())
-                .toLowerCase(Locale.ROOT);
+            .toLowerCase(Locale.ROOT);
     }
 }


### PR DESCRIPTION
Fixes DD-1186

# Description of changes

Puts the InvalidPartialFileException in a different catch block that propagates the exception message, instead of using a generic one. Also changes how the file is referenced; instead of using the full path it only shows the filename now.

# How to test


# Related PRs
(Add links)
*

# Notify
@DANS-KNAW/dataversedans
