### PR TITLE
Add multiple auth methods

### DIFF
--- a/src/main/java/nl/knaw/dans/sword2/DdSword2Application.java
+++ b/src/main/java/nl/knaw/dans/sword2/DdSword2Application.java
@@ -27,6 +27,7 @@ import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
 import nl.knaw.dans.sword2.core.auth.CombinedAuthenticationFilter;
 import nl.knaw.dans.sword2.core.auth.CombinedAuthenticator;
+import nl.knaw.dans.sword2.core.auth.DataverseAuthenticationServiceImpl;
 import nl.knaw.dans.sword2.core.auth.Depositor;
 import nl.knaw.dans.sword2.core.auth.HeaderAuthenticator;
 import nl.knaw.dans.sword2.core.auth.SwordAuthenticator;
@@ -113,8 +114,9 @@ public class DdSword2Application extends Application<DdSword2Configuration> {
         // Add a md5 output hash header
         environment.jersey().register(HashHeaderInterceptor.class);
 
-        var headerAuthenticator = new HeaderAuthenticator(configuration.getAuthorization(), httpClient, environment.getObjectMapper());
-        var swordAuthenticator = new SwordAuthenticator(configuration.getAuthorization(), httpClient);
+        var dataverseAuthenticator = new DataverseAuthenticationServiceImpl(configuration.getAuthorization().getPasswordDelegate(), httpClient, environment.getObjectMapper());
+        var headerAuthenticator = new HeaderAuthenticator(configuration.getAuthorization(), dataverseAuthenticator);
+        var swordAuthenticator = new SwordAuthenticator(configuration.getAuthorization(), dataverseAuthenticator);
 
         environment.jersey().register(new AuthDynamicFeature(
             new CombinedAuthenticationFilter.Builder<Depositor>()

--- a/src/main/java/nl/knaw/dans/sword2/DdSword2Configuration.java
+++ b/src/main/java/nl/knaw/dans/sword2/DdSword2Configuration.java
@@ -19,18 +19,16 @@ package nl.knaw.dans.sword2;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.dropwizard.Configuration;
 import io.dropwizard.client.HttpClientConfiguration;
+import nl.knaw.dans.sword2.core.config.AuthorizationConfig;
 import nl.knaw.dans.sword2.core.config.Sword2Config;
-import nl.knaw.dans.sword2.core.config.UserConfig;
 
 import javax.validation.Valid;
-import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
-import java.util.List;
 
 public class DdSword2Configuration extends Configuration {
 
     @Valid
-    private List<UserConfig> users;
+    private AuthorizationConfig authorization;
 
     @Valid
     @NotNull
@@ -47,14 +45,6 @@ public class DdSword2Configuration extends Configuration {
         this.sword2 = sword2;
     }
 
-    public List<UserConfig> getUsers() {
-        return users;
-    }
-
-    public void setUsers(List<UserConfig> users) {
-        this.users = users;
-    }
-
     @JsonProperty("httpClient")
     public HttpClientConfiguration getHttpClientConfiguration() {
         return httpClient;
@@ -63,5 +53,13 @@ public class DdSword2Configuration extends Configuration {
     @JsonProperty("httpClient")
     public void setHttpClientConfiguration(HttpClientConfiguration httpClient) {
         this.httpClient = httpClient;
+    }
+
+    public AuthorizationConfig getAuthorization() {
+        return authorization;
+    }
+
+    public void setAuthorization(AuthorizationConfig authorization) {
+        this.authorization = authorization;
     }
 }

--- a/src/main/java/nl/knaw/dans/sword2/core/auth/AuthUser.java
+++ b/src/main/java/nl/knaw/dans/sword2/core/auth/AuthUser.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2022 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.sword2.core.auth;
+
+import java.security.Principal;
+
+public class AuthUser implements Principal {
+    private final String name;
+
+    public AuthUser(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public String getName() {
+        return this.name;
+    }
+}

--- a/src/main/java/nl/knaw/dans/sword2/core/auth/CombinedAuthenticationFilter.java
+++ b/src/main/java/nl/knaw/dans/sword2/core/auth/CombinedAuthenticationFilter.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright (C) 2022 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.sword2.core.auth;
+
+import io.dropwizard.auth.AuthFilter;
+import io.dropwizard.auth.basic.BasicCredentials;
+
+import javax.annotation.Nullable;
+import javax.annotation.Priority;
+import javax.ws.rs.Priorities;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.SecurityContext;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.security.Principal;
+import java.util.Base64;
+import java.util.HashSet;
+import java.util.Objects;
+
+@Priority(Priorities.AUTHENTICATION)
+public class CombinedAuthenticationFilter<P extends Principal> extends AuthFilter<CombinedCredentials, P> {
+    private String headerName;
+
+    public CombinedAuthenticationFilter(String headerName) {
+        this.headerName = headerName;
+    }
+
+    @Override
+    public void filter(ContainerRequestContext requestContext) throws IOException {
+        var principals = getPrincipals(requestContext);
+
+        // not sure what will break if we put our custom auth method in here, so lets stick with BASIC_AUTH
+        if (!authenticate(requestContext, principals, SecurityContext.BASIC_AUTH)) {
+            throw unauthorizedHandler.buildException(prefix, realm);
+        }
+    }
+
+    private CombinedCredentials getPrincipals(ContainerRequestContext requestContext) {
+        var result = new CombinedCredentials();
+        var value = requestContext.getHeaders().getFirst(headerName);
+
+        if (value != null) {
+            result.setHeaderCredentials(new HeaderCredentials(value));
+        }
+
+        var basicCredentials = getBasicCredentials(requestContext.getHeaders().getFirst(HttpHeaders.AUTHORIZATION));
+
+        if (basicCredentials != null) {
+            result.setBasicCredentials(basicCredentials);
+        }
+
+        return result;
+    }
+
+    // Copied from io.dropwizard.auth.basic.BasicCredentialAuthFilter
+    @Nullable
+    private BasicCredentials getBasicCredentials(String header) {
+        if (header == null) {
+            return null;
+        }
+
+        final int space = header.indexOf(' ');
+        if (space <= 0) {
+            return null;
+        }
+
+        final String method = header.substring(0, space);
+        if (!prefix.equalsIgnoreCase(method)) {
+            return null;
+        }
+
+        final String decoded;
+        try {
+            decoded = new String(Base64.getDecoder().decode(header.substring(space + 1)), StandardCharsets.UTF_8);
+        }
+        catch (IllegalArgumentException e) {
+            logger.warn("Error decoding credentials", e);
+            return null;
+        }
+
+        // Decoded credentials is 'username:password'
+        final int i = decoded.indexOf(':');
+        if (i <= 0) {
+            return null;
+        }
+
+        final String username = decoded.substring(0, i);
+        final String password = decoded.substring(i + 1);
+        return new BasicCredentials(username, password);
+    }
+
+    public static class Builder<P extends Principal> extends
+        AuthFilterBuilder<CombinedCredentials, P, CombinedAuthenticationFilter<P>> {
+
+        private String headerName;
+
+        public Builder<P> setHeaderName(String headerName) {
+            this.headerName = headerName;
+            return this;
+        }
+
+        @Override
+        protected CombinedAuthenticationFilter<P> newInstance() {
+            return new CombinedAuthenticationFilter<>(headerName);
+        }
+    }
+}

--- a/src/main/java/nl/knaw/dans/sword2/core/auth/CombinedAuthenticator.java
+++ b/src/main/java/nl/knaw/dans/sword2/core/auth/CombinedAuthenticator.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2022 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.sword2.core.auth;
+
+import io.dropwizard.auth.AuthenticationException;
+import io.dropwizard.auth.Authenticator;
+
+import java.util.Optional;
+
+public class CombinedAuthenticator implements Authenticator<CombinedCredentials, Depositor> {
+    private final SwordAuthenticator swordAuthenticator;
+    private final HeaderAuthenticator headerAuthenticator;
+
+    public CombinedAuthenticator(SwordAuthenticator swordAuthenticator, HeaderAuthenticator headerAuthenticator) {
+        this.swordAuthenticator = swordAuthenticator;
+        this.headerAuthenticator = headerAuthenticator;
+    }
+
+    @Override
+    public Optional<Depositor> authenticate(CombinedCredentials credentials) throws AuthenticationException {
+        // if header credentials are provided, only use that
+        if (credentials.getHeaderCredentials() != null) {
+            return headerAuthenticator.authenticate(credentials.getHeaderCredentials());
+        }
+
+        // if basic credentials are provided, and header credentials are not provided, only use basic
+        if (credentials.getBasicCredentials() != null) {
+            return swordAuthenticator.authenticate(credentials.getBasicCredentials());
+        }
+
+        return Optional.empty();
+    }
+
+}

--- a/src/main/java/nl/knaw/dans/sword2/core/auth/CombinedCredentials.java
+++ b/src/main/java/nl/knaw/dans/sword2/core/auth/CombinedCredentials.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2022 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.sword2.core.auth;
+
+import io.dropwizard.auth.basic.BasicCredentials;
+
+public class CombinedCredentials {
+    private BasicCredentials basicCredentials;
+    private HeaderCredentials headerCredentials;
+
+    public CombinedCredentials() {
+
+    }
+
+    public CombinedCredentials(BasicCredentials basicCredentials, HeaderCredentials headerCredentials) {
+        this.basicCredentials = basicCredentials;
+        this.headerCredentials = headerCredentials;
+    }
+
+    public BasicCredentials getBasicCredentials() {
+        return basicCredentials;
+    }
+
+    public void setBasicCredentials(BasicCredentials basicCredentials) {
+        this.basicCredentials = basicCredentials;
+    }
+
+    public HeaderCredentials getHeaderCredentials() {
+        return headerCredentials;
+    }
+
+    public void setHeaderCredentials(HeaderCredentials headerCredentials) {
+        this.headerCredentials = headerCredentials;
+    }
+}

--- a/src/main/java/nl/knaw/dans/sword2/core/auth/DataverseAuthenticationService.java
+++ b/src/main/java/nl/knaw/dans/sword2/core/auth/DataverseAuthenticationService.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2022 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.sword2.core.auth;
+
+import io.dropwizard.auth.AuthenticationException;
+import io.dropwizard.auth.basic.BasicCredentials;
+
+import java.util.Optional;
+
+public interface DataverseAuthenticationService {
+
+    Optional<String> authenticateWithHeader(String value) throws AuthenticationException;
+
+    Optional<String> authenticateWithBasic(BasicCredentials value) throws AuthenticationException;
+}

--- a/src/main/java/nl/knaw/dans/sword2/core/auth/DataverseAuthenticationServiceImpl.java
+++ b/src/main/java/nl/knaw/dans/sword2/core/auth/DataverseAuthenticationServiceImpl.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (C) 2022 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.sword2.core.auth;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.dropwizard.auth.AuthenticationException;
+import io.dropwizard.auth.basic.BasicCredentials;
+import org.apache.commons.codec.binary.Base64;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.methods.HttpUriRequest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.Optional;
+
+public class DataverseAuthenticationServiceImpl implements DataverseAuthenticationService {
+    private static final Logger log = LoggerFactory.getLogger(DataverseAuthenticationServiceImpl.class);
+    private final URL passwordDelegate;
+    private final HttpClient httpClient;
+    private final ObjectMapper objectMapper;
+
+    public DataverseAuthenticationServiceImpl(URL passwordDelegate, HttpClient httpClient, ObjectMapper objectMapper) {
+        this.passwordDelegate = passwordDelegate;
+        this.httpClient = httpClient;
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public Optional<String> authenticateWithHeader(String value) throws AuthenticationException {
+        try {
+            var post = new HttpPost(passwordDelegate.toURI());
+            post.setHeader("X-Dataverse-Key", value);
+
+            return doRequest(post);
+        }
+        catch (URISyntaxException | IOException e) {
+            throw new AuthenticationException("Unable to validate credentials", e);
+        }
+    }
+
+    @Override
+    public Optional<String> authenticateWithBasic(BasicCredentials basicCredentials) throws AuthenticationException {
+        var auth = basicCredentials.getUsername() + ":" + basicCredentials.getPassword();
+        var encodedAuth = Base64.encodeBase64(auth.getBytes(StandardCharsets.UTF_8));
+        var header = String.format("Basic %s", new String(encodedAuth, StandardCharsets.UTF_8));
+
+        try {
+            var post = new HttpPost(passwordDelegate.toURI());
+            post.setHeader("Authorization", header);
+
+            return doRequest(post);
+        }
+        catch (URISyntaxException | IOException e) {
+            throw new AuthenticationException("Unable to validate credentials", e);
+        }
+    }
+
+    private Optional<String> doRequest(HttpUriRequest request) throws AuthenticationException, IOException {
+        var response = httpClient.execute(request);
+        var status = response.getStatusLine().getStatusCode();
+        log.debug("Delegate returned status code {}", status);
+
+        switch (status) {
+            case 200:
+                return getUsernameFromResponse(response);
+            case 401:
+                return Optional.empty();
+            default:
+                throw new AuthenticationException(String.format(
+                    "Unexpected status code returned: %s (message: %s)", status, response.getStatusLine().getReasonPhrase()
+                ));
+        }
+    }
+
+    private Optional<String> getUsernameFromResponse(HttpResponse response) {
+        try {
+            var tree = objectMapper.readTree(response.getEntity().getContent());
+            return Optional.ofNullable(tree.get("userId").asText());
+        }
+        catch (Exception e) {
+            log.error("Error parsing JSON", e);
+        }
+
+        return Optional.empty();
+    }
+}

--- a/src/main/java/nl/knaw/dans/sword2/core/auth/HeaderAuthenticator.java
+++ b/src/main/java/nl/knaw/dans/sword2/core/auth/HeaderAuthenticator.java
@@ -15,18 +15,12 @@
  */
 package nl.knaw.dans.sword2.core.auth;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.dropwizard.auth.AuthenticationException;
 import io.dropwizard.auth.Authenticator;
 import nl.knaw.dans.sword2.core.config.AuthorizationConfig;
-import org.apache.http.HttpResponse;
-import org.apache.http.client.HttpClient;
-import org.apache.http.client.methods.HttpPost;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
-import java.net.URISyntaxException;
 import java.util.HashSet;
 import java.util.Optional;
 
@@ -35,68 +29,26 @@ public class HeaderAuthenticator implements Authenticator<HeaderCredentials, Dep
     private static final Logger log = LoggerFactory.getLogger(HeaderAuthenticator.class);
 
     private final AuthorizationConfig authorizationConfig;
-    private final HttpClient httpClient;
 
-    private final ObjectMapper objectMapper;
+    private final DataverseAuthenticationService dataverseAuthenticationService;
 
-    public HeaderAuthenticator(AuthorizationConfig authorizationConfig, HttpClient httpClient, ObjectMapper objectMapper) {
+    public HeaderAuthenticator(AuthorizationConfig authorizationConfig, DataverseAuthenticationService dataverseAuthenticationService) {
         this.authorizationConfig = authorizationConfig;
-        this.httpClient = httpClient;
-        this.objectMapper = objectMapper;
+        this.dataverseAuthenticationService = dataverseAuthenticationService;
     }
 
     @Override
     public Optional<Depositor> authenticate(HeaderCredentials credentials) throws AuthenticationException {
         if (authorizationConfig.getPasswordDelegate() == null) {
+            log.warn("No password delegate configured, not proceeding");
             return Optional.empty();
         }
 
-        var userName = getUserNameFromToken(credentials);
+        var userName = dataverseAuthenticationService.authenticateWithHeader(credentials.getValue());
 
         return userName.flatMap(s -> authorizationConfig.getUsers().stream()
             .filter(m -> m.getName().equals(s))
             .map(m -> new Depositor(m.getName(), m.getFilepathMapping(), new HashSet<>(m.getCollections())))
             .findFirst());
-
-    }
-
-    Optional<String> getUserNameFromToken(HeaderCredentials credentials) throws AuthenticationException {
-        return getAuthenticatedResponse(credentials)
-            .map((m) -> {
-                try {
-                    var tree = objectMapper.readTree(m.getEntity().getContent());
-                    return tree.get("userId").asText();
-                }
-                catch (Exception e) {
-                    log.error("Error parsing JSON", e);
-                }
-
-                return null;
-            });
-    }
-
-    Optional<HttpResponse> getAuthenticatedResponse(HeaderCredentials credentials) throws AuthenticationException {
-        try {
-            var post = new HttpPost(authorizationConfig.getPasswordDelegate().toURI());
-            post.setHeader("X-Dataverse-Key", credentials.getValue());
-
-            var response = httpClient.execute(post);
-            var status = response.getStatusLine().getStatusCode();
-            log.debug("Delegate returned status code {}", status);
-
-            switch (status) {
-                case 200:
-                    return Optional.of(response);
-                case 401:
-                    return Optional.empty();
-                default:
-                    throw new AuthenticationException(String.format(
-                        "Unexpected status code returned: %s (message: %s)", status, response.getStatusLine().getReasonPhrase()
-                    ));
-            }
-        }
-        catch (URISyntaxException | IOException e) {
-            throw new AuthenticationException("Unable to validate credentials", e);
-        }
     }
 }

--- a/src/main/java/nl/knaw/dans/sword2/core/auth/HeaderAuthenticator.java
+++ b/src/main/java/nl/knaw/dans/sword2/core/auth/HeaderAuthenticator.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (C) 2022 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.sword2.core.auth;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.dropwizard.auth.AuthenticationException;
+import io.dropwizard.auth.Authenticator;
+import nl.knaw.dans.sword2.core.config.AuthorizationConfig;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.HttpPost;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.util.HashSet;
+import java.util.Optional;
+
+public class HeaderAuthenticator implements Authenticator<HeaderCredentials, Depositor> {
+
+    private static final Logger log = LoggerFactory.getLogger(HeaderAuthenticator.class);
+
+    private final AuthorizationConfig authorizationConfig;
+    private final HttpClient httpClient;
+
+    private final ObjectMapper objectMapper;
+
+    public HeaderAuthenticator(AuthorizationConfig authorizationConfig, HttpClient httpClient, ObjectMapper objectMapper) {
+        this.authorizationConfig = authorizationConfig;
+        this.httpClient = httpClient;
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public Optional<Depositor> authenticate(HeaderCredentials credentials) throws AuthenticationException {
+        if (authorizationConfig.getPasswordDelegate() == null) {
+            return Optional.empty();
+        }
+
+        var userName = getUserNameFromToken(credentials);
+
+        return userName.flatMap(s -> authorizationConfig.getUsers().stream()
+            .filter(m -> m.getName().equals(s))
+            .map(m -> new Depositor(m.getName(), m.getFilepathMapping(), new HashSet<>(m.getCollections())))
+            .findFirst());
+
+    }
+
+    Optional<String> getUserNameFromToken(HeaderCredentials credentials) throws AuthenticationException {
+        return getAuthenticatedResponse(credentials)
+            .map((m) -> {
+                try {
+                    var tree = objectMapper.readTree(m.getEntity().getContent());
+                    return tree.get("userId").asText();
+                }
+                catch (Exception e) {
+                    log.error("Error parsing JSON", e);
+                }
+
+                return null;
+            });
+    }
+
+    Optional<HttpResponse> getAuthenticatedResponse(HeaderCredentials credentials) throws AuthenticationException {
+        try {
+            var post = new HttpPost(authorizationConfig.getPasswordDelegate().toURI());
+            post.setHeader("X-Dataverse-Key", credentials.getValue());
+
+            var response = httpClient.execute(post);
+            var status = response.getStatusLine().getStatusCode();
+            log.debug("Delegate returned status code {}", status);
+
+            switch (status) {
+                case 200:
+                    return Optional.of(response);
+                case 401:
+                    return Optional.empty();
+                default:
+                    throw new AuthenticationException(String.format(
+                        "Unexpected status code returned: %s (message: %s)", status, response.getStatusLine().getReasonPhrase()
+                    ));
+            }
+        }
+        catch (URISyntaxException | IOException e) {
+            throw new AuthenticationException("Unable to validate credentials", e);
+        }
+    }
+}

--- a/src/main/java/nl/knaw/dans/sword2/core/auth/HeaderCredentials.java
+++ b/src/main/java/nl/knaw/dans/sword2/core/auth/HeaderCredentials.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2022 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.sword2.core.auth;
+
+public class HeaderCredentials {
+    private final String value;
+
+    public HeaderCredentials(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return "HeaderCredentials{" +
+            "value='" + value + '\'' +
+            '}';
+    }
+}

--- a/src/main/java/nl/knaw/dans/sword2/core/config/AuthorizationConfig.java
+++ b/src/main/java/nl/knaw/dans/sword2/core/config/AuthorizationConfig.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2022 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.sword2.core.config;
+
+import javax.validation.Valid;
+import java.net.URL;
+import java.util.List;
+
+public class AuthorizationConfig {
+
+    @Valid
+    private URL passwordDelegate;
+    @Valid
+    private List<UserConfig> users;
+
+    public URL getPasswordDelegate() {
+        return passwordDelegate;
+    }
+
+    public void setPasswordDelegate(URL passwordDelegate) {
+        this.passwordDelegate = passwordDelegate;
+    }
+
+    public List<UserConfig> getUsers() {
+        return users;
+    }
+
+    public void setUsers(List<UserConfig> users) {
+        this.users = users;
+    }
+
+    @Override
+    public String toString() {
+        return "AuthorizationConfig{" +
+            "passwordDelegate=" + passwordDelegate +
+            ", users=" + users +
+            '}';
+    }
+}

--- a/src/main/java/nl/knaw/dans/sword2/core/config/UserConfig.java
+++ b/src/main/java/nl/knaw/dans/sword2/core/config/UserConfig.java
@@ -15,16 +15,13 @@
  */
 package nl.knaw.dans.sword2.core.config;
 
-import javax.validation.constraints.AssertTrue;
 import javax.validation.constraints.NotEmpty;
-import java.net.URL;
 import java.util.List;
 
 public class UserConfig {
     @NotEmpty
     private String name;
     private String passwordHash;
-    private URL passwordDelegate;
     private Boolean filepathMapping;
     @NotEmpty
     private List<String> collections;
@@ -33,25 +30,11 @@ public class UserConfig {
 
     }
 
-    public UserConfig(String name, String passwordHash, Boolean filepathMapping, List<String> collections, URL passwordDelegate) {
+    public UserConfig(String name, String passwordHash, Boolean filepathMapping, List<String> collections) {
         this.name = name;
         this.passwordHash = passwordHash;
         this.filepathMapping = filepathMapping;
         this.collections = collections;
-        this.passwordDelegate = passwordDelegate;
-    }
-
-    @AssertTrue(message = "either passwordHash or passwordDelegate must be set, but not both")
-    boolean isPasswordMethodsMutuallyExclusive() {
-        return this.passwordHash != null ^ this.passwordDelegate != null;
-    }
-
-    public URL getPasswordDelegate() {
-        return passwordDelegate;
-    }
-
-    public void setPasswordDelegate(URL passwordDelegate) {
-        this.passwordDelegate = passwordDelegate;
     }
 
     public String getName() {

--- a/src/test/java/nl/knaw/dans/sword2/auth/SwordAuthenticatorTest.java
+++ b/src/test/java/nl/knaw/dans/sword2/auth/SwordAuthenticatorTest.java
@@ -93,7 +93,7 @@ class SwordAuthenticatorTest {
         var userList = List.of(new UserConfig("user001", null, false, new ArrayList<>()));
 
         var protocol = new ProtocolVersion("http", 1, 1);
-        var status = new BasicStatusLine(protocol, 204, "No Content");
+        var status = new BasicStatusLine(protocol, 200, "No Content");
         var fakeResponse = new BasicHttpResponse(status, null, null);
 
         Mockito.when(httpClient.execute(Mockito.any()))

--- a/src/test/java/nl/knaw/dans/sword2/core/auth/HeaderAuthenticatorTest.java
+++ b/src/test/java/nl/knaw/dans/sword2/core/auth/HeaderAuthenticatorTest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (C) 2022 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.sword2.core.auth;
+
+import io.dropwizard.auth.AuthenticationException;
+import nl.knaw.dans.sword2.core.config.AuthorizationConfig;
+import nl.knaw.dans.sword2.core.config.UserConfig;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class HeaderAuthenticatorTest {
+
+    private final DataverseAuthenticationService authenticationService = Mockito.mock(DataverseAuthenticationService.class);
+    private final URL passwordDelegate = new URL("http://test.com/");
+
+    HeaderAuthenticatorTest() throws MalformedURLException {
+    }
+
+    @BeforeEach
+    void setUp() {
+        Mockito.reset(authenticationService);
+    }
+
+    HeaderAuthenticator getAuthenticator(List<UserConfig> users) {
+        var config = new AuthorizationConfig();
+        config.setUsers(users);
+        config.setPasswordDelegate(passwordDelegate);
+
+        return new HeaderAuthenticator(config, authenticationService);
+    }
+
+    @Test
+    void authenticate_should_return_empty_optional_if_no_users_are_configured() {
+        var emptyList = new ArrayList<UserConfig>();
+
+        var result = assertDoesNotThrow(() ->
+            getAuthenticator(List.of()).authenticate(new HeaderCredentials("token"))
+        );
+
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void authenticate_should_call_delegate_http_service() throws AuthenticationException {
+        var userList = List.of(new UserConfig("user001", null, false, new ArrayList<>()));
+
+        Mockito.when(authenticationService.authenticateWithHeader(Mockito.any()))
+            .thenReturn(Optional.of("user001"));
+
+        assertEquals("user001", getAuthenticator(userList).authenticate(new HeaderCredentials("token")).get().getName());
+    }
+
+    @Test
+    void authenticate_should_return_empty_optional_if_delegate_returns_401_unauthorized() throws AuthenticationException {
+        var userList = List.of(new UserConfig("user001", null, false, new ArrayList<>()));
+
+        Mockito.when(authenticationService.authenticateWithHeader(Mockito.any()))
+            .thenReturn(Optional.empty());
+
+        assertTrue(getAuthenticator(userList)
+            .authenticate(new HeaderCredentials("token")).isEmpty());
+    }
+
+    @Test
+    void authenticate_should_return_empty_optional_if_users_do_not_match() throws AuthenticationException {
+        var userList = List.of(new UserConfig("user001", null, false, new ArrayList<>()));
+
+        Mockito.when(authenticationService.authenticateWithHeader(Mockito.any()))
+            .thenReturn(Optional.of("different_user"));
+
+        assertTrue(getAuthenticator(userList)
+            .authenticate(new HeaderCredentials("token")).isEmpty());
+    }
+
+    @Test
+    void authenticate_should_propagate_AuthenticationException() throws AuthenticationException {
+        var userList = List.of(new UserConfig("user001", null, false, new ArrayList<>()));
+
+        Mockito.doThrow(AuthenticationException.class)
+            .when(authenticationService).authenticateWithHeader(Mockito.any());
+
+        assertThrows(AuthenticationException.class, () -> getAuthenticator(userList)
+            .authenticate(new HeaderCredentials("token")));
+    }
+}

--- a/src/test/resources/test-etc/config-bagsender.yml
+++ b/src/test/resources/test-etc/config-bagsender.yml
@@ -13,12 +13,13 @@ server:
   requestLog:
     appenders: [ ]
 
-users:
-  - name: 'user001'
-    passwordHash: '$2a$10$yvmSYczU7z4KL6qmRCTgTeSvo7uurwPUbB9s/mTKzJrYM/sQKgF.y'
-    filepathMapping: true
-    collections:
-      - collection1
+authorization:
+  users:
+    - name: 'user001'
+      passwordHash: '$2a$10$yvmSYczU7z4KL6qmRCTgTeSvo7uurwPUbB9s/mTKzJrYM/sQKgF.y'
+      filepathMapping: true
+      collections:
+        - collection1
 
 sword2:
   baseUrl: 'http://localhost:20320/'

--- a/src/test/resources/test-etc/config-bigmargin.yml
+++ b/src/test/resources/test-etc/config-bigmargin.yml
@@ -13,12 +13,13 @@ server:
   requestLog:
     appenders: []
 
-users:
-  - name: 'user001'
-    passwordHash: '$2a$10$yvmSYczU7z4KL6qmRCTgTeSvo7uurwPUbB9s/mTKzJrYM/sQKgF.y'
-    filepathMapping: true
-    collections:
-      - collection1
+authorization:
+  users:
+    - name: 'user001'
+      passwordHash: '$2a$10$yvmSYczU7z4KL6qmRCTgTeSvo7uurwPUbB9s/mTKzJrYM/sQKgF.y'
+      filepathMapping: true
+      collections:
+        - collection1
 
 sword2:
   baseUrl: 'http://localhost:20320/'

--- a/src/test/resources/test-etc/config-regular.yml
+++ b/src/test/resources/test-etc/config-regular.yml
@@ -12,12 +12,13 @@ server:
   requestLog:
     appenders: [ ]
 
-users:
-  - name: 'user001'
-    passwordHash: '$2a$10$yvmSYczU7z4KL6qmRCTgTeSvo7uurwPUbB9s/mTKzJrYM/sQKgF.y' # user001
-    filepathMapping: true
-    collections:
-      - collection1
+authorization:
+  users:
+    - name: 'user001'
+      passwordHash: '$2a$10$yvmSYczU7z4KL6qmRCTgTeSvo7uurwPUbB9s/mTKzJrYM/sQKgF.y' # user001
+      filepathMapping: true
+      collections:
+        - collection1
 
 sword2:
   baseUrl: 'http://localhost:20320/'

--- a/src/test/resources/test-etc/config-servicedocument.yml
+++ b/src/test/resources/test-etc/config-servicedocument.yml
@@ -13,13 +13,14 @@ server:
   requestLog:
     appenders: []
 
-users:
-  - name: 'user001'
-    passwordHash: '$2a$10$yvmSYczU7z4KL6qmRCTgTeSvo7uurwPUbB9s/mTKzJrYM/sQKgF.y'
-    filepathMapping: true
-    collections:
-      - collection1
-      - collection2
+authorization:
+  users:
+    - name: 'user001'
+      passwordHash: '$2a$10$yvmSYczU7z4KL6qmRCTgTeSvo7uurwPUbB9s/mTKzJrYM/sQKgF.y'
+      filepathMapping: true
+      collections:
+        - collection1
+        - collection2
 
 sword2:
   baseUrl: 'http://localhost:20320/'


### PR DESCRIPTION
Fixes DD-1307

# Description of changes

Adds support for x-dataverse-key authentication. Due to the way dropwizard (and jersey) support auth, it was not possible to use the ChainedAuthFilter because it exhibits strange behaviour. It is actually possible to provide incorrect credentials for one method and still be correctly authenticated.

We figured that providing incorrect credentials should always result in denying access, even if correct credentials are provided in another mechanism. 

Hence the custom implementation, similar to what was done in dd-dataverse-authenticator.

# How to test

# Related PRs

(Add links)

*

# Notify

@DANS-KNAW/dataversedans
